### PR TITLE
Addding Session 3: Trigger Concepts

### DIFF
--- a/Session3/Session3_TriggerConcepts.ipynb
+++ b/Session3/Session3_TriggerConcepts.ipynb
@@ -1,0 +1,616 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dcc4a334",
+   "metadata": {
+    "id": "dcc4a334"
+   },
+   "source": [
+    "## Trigger Conceps\n",
+    "\n",
+    "Most particle physics experiments will use a trigger during data acquisition as opposed to streaming out the data continuously. A trigger is a signal that tells the data aquisition system to read out the detector data corresponding to an instance in time (an event) for storage. The latency of a trigger decision is dictated by the buffer size of the system: A trigger decision cannot take longer than the time you can afford to temporarily store the detector data for consecutive events of interests.\n",
+    "\n",
+    "\n",
+    "### Why does ATLAS need a trigger\n",
+    "\n",
+    "The environment at the proton-proton interaction point is extremely busy: We have up to 60 proton interactions per bunch crossings, and 30 million bunch crossings per second!\n",
+    "\n",
+    "<img src=\"https://s-media-cache-ak0.pinimg.com/originals/3e/cd/07/3ecd07951c28fd36eee321274c82310a.jpg\" width=\"500\" />\n",
+    "\n",
+    "ATLAS needs a way to be _highly selective_ of the events of interest to keep: Without a trigger system we would need to find a way to record > 40 TB of data per second! \n",
+    "\n",
+    "### What does the trigger select?\n",
+    "\n",
+    "\"Highly selective\" often simply means a requirement of an event to contain reconstructed particles with transverse momentum or energy, $p_T$ or $E_T$, above a certain threshold.\n",
+    "\n",
+    "**Why?** This is because the $p_T$/$E_T$ distribution of background particles is exponentially falling:\n",
+    "<img src=\"http://opendata.atlas.cern/release/2020/documentation/8TeVDoc/pictures/Output/jet_pt.jpg\" width=\"500\" />\n",
+    "Meaning:\n",
+    "- Energetic events (in transverse plane) are more interesting because of the lower background rate.\n",
+    "- The $p_T$ threshold is an easy way to controlling trigger rates with intensifying LHC conditions.\n",
+    "    \n",
+    " > **It does not mean there is no interesting physics below threshold! It is just much more challenging to look there.**\n",
+    "\n",
+    "Beside a requirement on the minimum $p_T$, a trigger selection can also require:\n",
+    "- A certain multiplicity of objects, e.g. 4 hadronic jets with $p_T$ > 100 GeV.\n",
+    "- Additional requirements on particle characteristic, e.g. minimum of 2 hadronic jets that have an 85% probability of being initiated by a bottom quark (\"b-tagging\").\n",
+    "- And even requirements on the event topology, e.g. a requirement of two jets with a high combined invariant mass.\n",
+    "\n",
+    "In reality, we have 100s of trigger selections that run parallel, deciding separately what events to keep. \n",
+    "\n",
+    "\n",
+    "### The impact of triggers on physics analysis\n",
+    "\n",
+    "Beside irrevocably determing which events are stored for an analysis, the decision also impacts the sensitivity of your analysis.\n",
+    "The latter is not only because it will dictate the energy threshold of leading particles in your events for analysis! As already stated, the triggers are required to make a decision within a certain amount of time. This gives them limited amount of time to reconstruct particles to base the decisions on, meaning we will not reconstruct particles as precisely online as we would in stored data. In addition, refinements such as calibration constants and detector alignments can be done later on on offline stored data, which may again deteriote the online reconstruction performance with respect to offline reconstruction performance.\n",
+    "\n",
+    "There are therefore two important concepts related to trigger and your physics analysis:\n",
+    "* *Important Trigger Concept 1*: Because of our highly selective trigger, our dataset is heavily biased. When analysing data, the very first step is to choose the trigger that is most appropriate for your physics analysis (the one that has the largest acceptance for your signal) and then filter the data based on whether that trigger fired.\n",
+    "* *Important Trigger Concept 2*: Your selection of physics events will depend on the trigger selection _and_ selection efficiency when the data was taken: Electrons reconstructed more precisely offline may not have had the same measured $p_T$ online, nor have even been correctly identified as an electron.\n",
+    "\n",
+    "\n",
+    "### Measuring trigger efficiencies\n",
+    "\n",
+    "We usually measure the trigger efficiency via \"**trigger efficiency turn-on curves**\". Turn-on curves simply measure the number of events kept by the trigger/total number of events$^*$ for events containing your signal, as a function of one of the variables used in the trigger selection, usually the $p_T$ of the reconstructed particles.\n",
+    "\n",
+    "\n",
+    "So let's first get to grips with the concept of trigger turn-ons.\n",
+    "\n",
+    "\n",
+    "$^*$_By the way, you may ask how do we know the total number of events if they were not triggered by our chosen trigger? What are your ideas?_\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85bab724",
+   "metadata": {},
+   "source": [
+    "# Exercise 1: Emulating a single jet trigger\n",
+    "\n",
+    "For the first exercise, we will be emulating a simple jet trigger by generating the momentum spectra of online and offline reconstructed jets. This allows us to study the performance of the trigger in detail: What impacts the trigger performance?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "55b0cee5",
+   "metadata": {
+    "id": "55b0cee5"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52e17660",
+   "metadata": {
+    "id": "52e17660"
+   },
+   "outputs": [],
+   "source": [
+    "#%matplotlib notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ae0c9ccc",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 449
+    },
+    "id": "ae0c9ccc",
+    "outputId": "cb911efb-68a5-4f4a-908f-ec28167fc041"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEGCAYAAACUzrmNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAYqklEQVR4nO3de7BlZXnn8e9PREGFINKQlgZbDUjQSal0ENOWEnUUiRFMNIOXSCoknTFkouWYAMHENhUjGTOMo1FKHC3aUUDiZSCWiMjYZexBSHNRGgFpB0Y69NBIVBqnJFye+WMtZJ/d5+y1T3fvyznn+6natdd691p7PWdVn/P0e1nvm6pCkqRBHjPpACRJ089kIUnqZLKQJHUyWUiSOpksJEmdHjvpAEblgAMOqJUrV046DElaUK655pofVNWy/vJFmyxWrlzJxo0bJx2GJC0oSf7PbOU2Q0mSOpksJEmdTBaSpE4mC0lSJ5OFJKmTyUKS1MlkIUnqZLKQJHUyWUiSOi3aJ7h3xbHHXjjw8/XrTxpTJJI0HaxZSJI6mSwkSZ1MFpKkTiYLSVInk4UkqZPJQpLUyWQhSepkspAkdTJZSJI6mSwkSZ1MFpKkTiYLSVInk4UkqZPJQpLUyWQhSerkehY7oXe9C9e2kLQUmCx2wuG3f7Znz2QhafGzGUqS1MlkIUnqZLKQJHUyWUiSOpksJEmdHA01hJmjnyRp6TFZ7KINa9fO2F/dty9Ji4HNUJKkTtYsdtG68zbN2F+9djJxSNIomSx2M5ulJC1GI2+GSrJHkuuSfLHd3z/J5Ulubd+f3HPsGUk2J7klySt7yo9KckP72QeTZNRxS5IeNY4+i7cBN/Xsnw5cUVWHAVe0+yQ5kmaipWcDxwEfSbJHe845wBrgsPZ13BjiliS1RtoMlWQF8GvAe4F3tMUnAMe22+uA9cBpbfmFVXU/cFuSzcDRSW4H9q2qK9vv/CRwInDpKGPfWfZhSFqMRl2z+ADwp8DDPWUHVdVWgPb9wLb8YOCOnuO2tGUHt9v95TtIsibJxiQb77777t3yA0iSRpgskrwa2FZV1wx7yixlNaB8x8Kqc6tqVVWtWrZs2ZCXlSR1GWUz1GrgNUmOB/YC9k3yKeCuJMuramuS5cC29vgtwCE9568A7mzLV8xSLkkak5Eli6o6AzgDIMmxwDur6s1J3g+cDJzVvl/cnnIJcH6Ss4Gn0nRkX11VDyXZnuQY4CrgLcCHRhX37ta7qh64sp6khWkSz1mcBVyU5BTg+8DrAarqxiQXAd8BHgROraqH2nPeCpwH7E3TsT2VnduStFiNJVlU1XqaUU9U1T3Ay+Y47r00I6f6yzcCzxldhJKkQXyCe8R2nLHWZihJC48TCUqSOpksJEmdTBaSpE4mC0lSJ5OFJKmTyUKS1MlkIUnqZLKQJHUyWUiSOpksJEmdnO5jzDasXTtjf3XfviRNI2sWkqROJgtJUiebocZs3XmbZuyvXjuZOCRpPqxZSJI6WbOYsN5lV11yVdK0smYhSepkspAkdbIZasJmLrtqM5Sk6WTNQpLUyWQhSepkM9QUcSoQSdPKmoUkqZPJQpLUyWQhSepkn8UU6326G3zCW9LkmCxmMfPZB0mSyWKK9M9Iy8ojJhOIJPWZs88iyZ7jDESSNL0GdXD/c5KPJXlpkowtIknS1BmULH4R2Aj8OXBHkg8kecF4wpIkTZM5k0VV3VNVH62qXwWOBm4DPpDke0neO7YIJUkTN1QHd1XdmeTjwA+BdwC/B5w5ysA026gsh85KmoyBD+Ul2SvJ65N8Hvge8DLgDOCp4whOkjQd5qxZJDkfeDnwdeB84I1V9dNhvzjJXu25j2+v89mqeneS/YHPACuB24HfqqoftuecAZwCPAT8cVVd1pYfBZwH7A18CXhbVdV8ftDFwIkGJU3KoGaoy4A/qKrtO/nd9wMvrar72mG430hyKfAbwBVVdVaS04HTgdOSHEnTzvJsmprLV5McXlUPAecAa4Bv0iSL44BLdzKuBav/OYzVaycTh6SlZ1AH97qq2p7koCQfT/JlgCRHJjml64urcV+7u2f7KuAEYF1bvg44sd0+Abiwqu6vqtuAzcDRSZYD+1bVlW1t4pM950iSxmCYiQTPo6llLG/3vwu8fZgvT7JHkuuBbcDlVXUVcFBVbQVo3w9sDz8YuKPn9C1t2cHtdn/5bNdbk2Rjko133333MCFKkoYwTLI4oKouAh4GqKoHafoUOlXVQ1X1XGAFTS3hOQMOn+3BvxpQPtv1zq2qVVW1atmyZcOEKEkawjDJ4idJnkL7BzrJMcCP53ORqvoRsJ6mr+GutmmJ9n1be9gW4JCe01YAd7blK2YplySNyTDJ4h3AJcAzk2yg6TP4D10nJVmWZL92e2+akVU3t991cnvYycDF7fYlwElJHp/k6cBhwNVtU9X2JMe00468peccSdIYdD6UV1XXJnkJ8CyaJqFbquqBIb57ObAuyR40SemiqvpikiuBi9pO8u8Dr2+vc2OSi4DvAA8Cp7YjoQDeyqNDZy9lCY6EkqRJGvScxb40ndG3VtWD7dDWvYHnJ7msqu4a9MVV9W3gebOU30PzcN9s57wX2GEqkaraCAzq75AkjdCgZqi/BVb37L8PWAW8GHjPKIOSJE2XQc1Qvwz8Qc/+9qr6Y4Ak3xhpVJKkqTIoWTy2b0qN3+7Z3m804Wg+XKNb0rgMShYPJ/n5qvq/AFW1CSDJwbTPXGiynJVW0rgM6rN4P/APSV6cZJ/29RLgf7SfSZKWiDlrFlX1qSQ/AP6KZnK/Am4E/qKqHLoqSUvIwOcsqurLwJfHFIskaUoNtVKeFobe9S5c60LS7jTMdB+SpCXOZCFJ6jR0M1SSFwFHA5uq6iujC0k7q3clPVfRk7Q7zVmzSHJ1z/bvA38H7AO8u10OVZK0RAxqhtqzZ3sN8G+r6j3AK4A3jTQqSdJUGdQM9ZgkT6ZJKKmquwGq6idJHhxLdJKkqTAoWfwccA3NGhb1yNQfSZ7E7EudSpIWqUFPcK+c46OHgdeOJBrtNmtWvm7G/rk7zCMlScMbtPjRRmADzap066vqpwBV9f+A28YTnnYXZ6iVtCsGNUMdA7wIOA54T5J7gMuAS6vqu+MITruPM9RK2hWDmqEeBNa3L5IsB14F/FWSw4Arq+oPxxCjJGnChn4or6q2JjkP+CxwH/DCUQUlSZoundN9JDk/yb5Jngh8B7gF+I9VtWHk0UmSpsIwNYsjq+reJG8CvgScRjOk1gWQFjBHS0maj2EmEtwzyZ7AicDFVfXAaEOSJE2bYZLFR4HbgScCX0/yNODHowxKkjRdhkkW/1BVB1fV8VVVwPeB3x1xXJKkKTJMsvhc706bMC6c41hJ0iI06AnuI4BnAz+X5Dd6PtoX2GvUgUmSpseg0VDPAl4N7Af8ek/5duD3RxiTJGnKDHqC+2Lg4iQvrKorxxiTJGnKDPOcxeYkfwas7D2+quzklqQlYphkcTHwj8BXgYdGG44kaRoNkyyeUFWnjTwSSdLUGiZZfDHJ8VX1pZFHo4lx+g9JgwzznMXbaBLGT5Pcm2R7kntHHZgkaXp01iyqap9xBCJJml7DTFGeJG9O8uft/iFJjh7ivEOSfC3JTUluTPK2tnz/JJcnubV9f3LPOWck2ZzkliSv7Ck/KskN7WcfTJKd+3ElSTtjmGaoj9AsdPTGdv8+4MNDnPcgzboXv0izROupSY4ETgeuqKrDgCvafdrPTqJ5avw44CNJ9mi/6xxgDXBY+zpuiOtrF6xZ+bqfvSRpmGTxgqo6FfgpQFX9EHhc10lVtbWqrm23twM3AQcDJwDr2sPW0Ux9Tlt+YVXdX1W3AZuBo9vlXPetqivbeak+2XOOJGkMhhkN9UD7P/wCSLIMeHg+F0myEngecBVwUFVthZ8t1Xpge9jBwDd7TtvSlj3QbveXz3adNTQ1EA499ND5hKgBNqxdO2N/dd++pMVvmJrFB4EvAAcmeS/wDeCvh71AkifRzFz79qoaNIpqtn6IGlC+Y2HVuVW1qqpWLVu2bNgQJUkdhhkN9ekk1wAvo/nDfWJV3TTMl7cr7H0O+HRVfb4tvivJ8rZWsRzY1pZvAQ7pOX0FcGdbvmKWco3JuvM2zdhfvXYycUianM5kkeS/Ap+pqmE6tXvPC/Bx4KaqOrvno0uAk4Gz2veLe8rPT3I28FSajuyrq+qh9tmOY2iasd4CfGg+sWj3sllKWnqG6bO4FnhXksNpmqM+U1UbhzhvNfDbwA1Jrm/L/owmSVyU5BSaVfdeD1BVNya5CPgOzUiqU6vqkbmo3gqcB+wNXNq+JEljkmaA0RAHJvsDv0kzvPXQdujr1Fq1alVt3DhMTtuRw0Xnx6lBpMUjyTVVtaq/fJgO7kf8AnAEzVTlN++muCRJC8AwT3D/TZJbgb8ENgFHVdWvd5wmSVpEhumzuA14YVX9YNTBaGE69tgLZ+yvX3/ShCKRNCrDJItzgTcmeUZV/WWSQ4Gfr6qrRxybFojDd+izMFlIi80wfRYfppkb6g3t/naGmxtKkrRIDFOzeEFVPT/JddDMDZWkc24oSdLiMUzNYpfnhpIkLWzD1Cz654Z6HfCukUalBc0Ob2nxGencUFqa7PCWFp9hahZU1c34IJ4kLVlDJQtpV/ROn+LUINLCNJ/pPiRJS5TJQpLUyWYojVX/jL42S0kLgzULSVInk4UkqZPJQpLUyWQhSepkspAkdXI0lCbK0VHSwmCy0FRxEkJpOpksNFWchFCaTiYLTbUNa9fO2F/dty9pPOzgliR1smahqbbuvE0z9levnUwc0lJnzUKS1MmahRYU18aQJsNkoQXLYbbS+NgMJUnqZM1CC5bPZEjjY7LQouEzGdLo2AwlSepkzUKLhs9kSKNjstCSYTOVtPNshpIkdRpZskjyiSTbkmzqKds/yeVJbm3fn9zz2RlJNie5Jckre8qPSnJD+9kHk2RUMUuSZjfKZqjzgL8DPtlTdjpwRVWdleT0dv+0JEfSjHt8NvBU4KtJDq+qh4BzgDXAN4EvAccBl44wbi0S/Qsr9bNPQxreyJJFVX09ycq+4hOAY9vtdcB64LS2/MKquh+4Lclm4OgktwP7VtWVAEk+CZyIyUK7Qe8T4D79LQ027g7ug6pqK0BVbU1yYFt+ME3N4RFb2rIH2u3+8lklWUNTC+HQQw/djWFrMZr5UJ/JQhpkWjq4Z+uHqAHls6qqc6tqVVWtWrZs2W4LTpKWunHXLO5KsrytVSwHtrXlW4BDeo5bAdzZlq+YpVzarZyUUBps3MniEuBk4Kz2/eKe8vOTnE3TwX0YcHVVPZRke5JjgKuAtwAfGnPMWgL655nasPbmGfs+k6GlbmTJIskFNJ3ZByTZArybJklclOQU4PvA6wGq6sYkFwHfAR4ETm1HQgG8lWZk1d40Hdt2bkvSmKVqzi6ABW3VqlW1cePGnTq3a8illh4XWtJSkeSaqlrVXz4tHdySpCnm3FDSTrBDXEuNNQtJUidrFtIQ+vuxDt/hCGsWWtxMFtJu0Dv9+Znrj5jxmU1UWgxMFtJuMGPhpZVHzH2gtECZLKTdrP8BvzUrZ+47DFcLkR3ckqROJgtJUieboaQx8xkNLUQmC2nMnLRQC5HJQpoy/c902CGuaWCykKacy79qGpgspAmb8YyGNKVMFtKUc61wTQOThbSAdK21Yv+GRsVkIS0iG/pGUjmySruLyUJaxBxZpd3FZCEtIl2d5YOasUwkGsTpPiRJnaxZSJqV/R/qZbKQBHSPtFq9djxxaDqZLCQNpT+ZnPw7z/nZtrWOxc9kIWmn9Hamn7nemXQXO5OFpF3WNZOu65IvfCYLSbtd/xDew5m571KzC4/JQtLE9faHmDimk8lC0lTpH7Lb34TV3+RlchkPk4WkqdafHPrNZ5SWS9ruPJOFpKmyq+t7zDx/7YzPDr+9/7tnJguTydxMFpIWra7E09/k1Z9Mekd1LfVnSUwWkpasrmQyqJbSf25v8xcMbgJbiDUWk4UkDWF+iWXHBxV7+16OPZY5P4Pp7LQ3WUjSCAzqmO/qtO9vHus3iSYxk4UkTZnuWsz41yVZMOtZJDkuyS1JNic5fdLxSNJSsiCSRZI9gA8DrwKOBN6Q5MjJRiVJS8eCSBbA0cDmqvrfVfWvwIXACROOSZKWjIXSZ3EwcEfP/hbgBf0HJVkDrGl370tyy05e7wDgBzt57igZ1/wY1/wY1/xMZVwfS3Y1rqfNVrhQkkVmKasdCqrOBc7d5YslG6tq1a5+z+5mXPNjXPNjXPOz1OJaKM1QW4BDevZXAHdOKBZJWnIWSrL4J+CwJE9P8jiaCV0umXBMkrRkLIhmqKp6MMkfAZcBewCfqKobR3jJXW7KGhHjmh/jmh/jmp8lFVeqdmj6lyRphoXSDCVJmiCThSSpk8mixzRNKZLk9iQ3JLk+yca2bP8klye5tX1/8phi+USSbUk29ZTNGUuSM9p7eEuSV445rrVJ/rm9b9cnOX6ccSU5JMnXktyU5MYkb2vLJ3q/BsQ16fu1V5Krk3yrjes9bfmk79dccU30fvVca48k1yX5Yrs/+vtVVb6afps9gO8BzwAeB3wLOHKC8dwOHNBX9p+A09vt04G/GVMsLwaeD2zqioVmOpZvAY8Hnt7e0z3GGNda4J2zHDuWuIDlwPPb7X2A77bXnuj9GhDXpO9XgCe123sCVwHHTMH9miuuid6vnuu9Azgf+GK7P/L7Zc3iUQthSpETgHXt9jrgxHFctKq+DvzLkLGcAFxYVfdX1W3AZpp7O6645jKWuKpqa1Vd225vB26imYFgovdrQFxzGVdcVVX3tbt7tq9i8vdrrrjmMrZ/90lWAL8G/Le+64/0fpksHjXblCKDfplGrYCvJLmmncYE4KCq2grNLz9w4MSimzuWabiPf5Tk220z1SPV8bHHlWQl8Dya/5VOzf3qiwsmfL/aJpXrgW3A5VU1Ffdrjrhg8v++PgD8KfBwT9nI75fJ4lFDTSkyRqur6vk0M+2emuTFE4xlPiZ9H88Bngk8F9gK/Oe2fKxxJXkS8Dng7VV176BDZykbZ1wTv19V9VBVPZdmZoajkzxnwOGTjmui9yvJq4FtVXXNsKfMUrZTcZksHjVVU4pU1Z3t+zbgCzRVx7uSLAdo37dNKr4BsUz0PlbVXe0v+cPAx3i0yj22uJLsSfMH+dNV9fm2eOL3a7a4puF+PaKqfgSsB45jCu7XbHFNwf1aDbwmye00TeUvTfIpxnC/TBaPmpopRZI8Mck+j2wDrwA2tfGc3B52MnDxJOJrzRXLJcBJSR6f5OnAYcDV4wrqkV+Y1mtp7tvY4koS4OPATVV1ds9HE71fc8U1BfdrWZL92u29gZcDNzP5+zVrXJO+X1V1RlWtqKqVNH+j/mdVvZlx3K9R9dYvxBdwPM0oke8BZ04wjmfQjGD4FnDjI7EATwGuAG5t3/cfUzwX0FS5H6D5n8opg2IBzmzv4S3Aq8Yc138HbgC+3f6iLB9nXMCLaKr53waub1/HT/p+DYhr0vfrl4Dr2utvAv6i69/6hOOa6P3qi/FYHh0NNfL75XQfkqRONkNJkjqZLCRJnUwWkqROJgtJUieThSSpk8lCS16S/zXgs/2S/OE8v+8L7Yykm5P8uGeG0l/pO259OxPoa3rK3pHk5jQzDn8rydntw3RzXWttkvf1lT03yU3t9teS3Jdk1Xx+BqmfyUJLXlX9yoCP9wPmlSyq6rXVTBPxe8A/VtVz29dsSelNVXUJQJJ/T/MA5jFV9W+AX6Z5EnfvAZe7APh3fWUn0cxISlX9KrBxPvFLszFZaMlLcl/7/idJ/qmdJO497cdnAc9sawbv7ztvZVsLWNee89kkT9iFUM4E3lrN9BJU1b9W1VnVzi2V5BVJrkxybZK/T/KkqroF+FGSF/R8z2/RTAUh7TYmC4nmDzHNVAhH00wSd1Q7eePpwPfamsGfzHLqs4Bzq+qXgHuZZy2k5/r70KyfcNscnx8AvAt4eTUTTG6kWdMAmtrFSe1xxwD3VNWtOxOHNBeThdR4Rfu6DrgWOIImeXS5o6o2tNufoplWY2eEntlAk7yyrc3c3vZ1HEOzkM2Gdtrsk4GntYdfCLwuyWNoksYFOxmDNKfHTjoAaUoEeF9VfXRGYbP2wyD98+Xs1Pw5VXVvkp8keXpV3VZVlwGXpVk283FtfJdX1RtmOfeOdhbSlwC/CbxwZ2KQBrFmITUuA363Xe+BJAcnORDYTrMM6VwOTfLIH+c3AN/YhRjeB5zTM9tpgL3az74JrE7yC+1nT0hyeM+5FwD/habJbMsuxCDNymQhNatofoVmBNGVSW4APgvsU1X30DT9bOrv4G7dBJyc5NvA/jSL4+ysc4CvAle137eBplnsuqq6G/gd4IL2s2/SNJU94u+BZ2PHtkbEWWe1pCV5CnBtVT2t8+Adz11JM0X0oJXdBp2/HnhnVY10aOu4rqPFzZqFlqwkTwWuBP52QiH8C3Be70N5u1uSr9Gsj/LAqK6hpcGahSSpkzULSVInk4UkqZPJQpLUyWQhSepkspAkdfr/T5RZH8Q37xsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# A trigger turn-on emulator for a jet trigger\n",
+    "\n",
+    "## First we generate (our exponentially falling pT) spectrum for the offline reconstructed leading jet\n",
+    "\n",
+    "col_off = 'darkblue'\n",
+    "col_on = 'darkred'\n",
+    "col_off_kept = 'green'\n",
+    "\n",
+    "samples=int(1e5)\n",
+    "\n",
+    "offline_jets_pt = 100*numpy.random.exponential(scale=1, size=samples)\n",
+    "## cut out jets below zero\n",
+    "\n",
+    "# --- histogram settings --- \n",
+    "bin_width = 5 # GeV\n",
+    "h_min = 0\n",
+    "h_max = 400\n",
+    "bins = int((h_max-h_min)/bin_width)\n",
+    "\n",
+    "plt.hist(offline_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off)\n",
+    "\n",
+    "## We then generated the pT spectrum of the online reconstructed leading jets\n",
+    "## Online reconstruction is not the same as offline due to resolution differences! We'll quantify the \n",
+    "## the difference between online and offline jets via a resolution parameter, sigma.\n",
+    "\n",
+    "sigma = 5.\n",
+    "gauss = numpy.random.normal(loc=0,scale=sigma, size=samples)\n",
+    "\n",
+    "online_jets_pt = offline_jets_pt + gauss\n",
+    "\n",
+    "plt.hist(offline_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off)\n",
+    "plt.hist(online_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_on)\n",
+    "\n",
+    "plt.ylabel(f\"events/{bin_width} GeV\")\n",
+    "plt.xlabel(\"jet pT [GeV]\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "f5f18138",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 449
+    },
+    "id": "f5f18138",
+    "outputId": "7bfa260f-d4a4-4b33-a5f9-9154d9d7cdf8"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtoAAAEGCAYAAABb+jL6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAvMElEQVR4nO3de5hsVXnv++9P8IIXIsjSIJcsYtAEeLyxQogm2bpRQU0AjSR4koCRvYkeNJrERIjnbEncPIFodIuJGKIGcCtIVAJbRUUUjZGLC0RggchSOLKEAMELuHeCQt7zxxwNRa/q7uruqurqru/neeqpWWPOMedbs2aPGj1qzDFSVUiSJEkaroesdACSJEnSWmRFW5IkSRoBK9qSJEnSCFjRliRJkkbAirYkSZI0AtuudACjstNOO9X69etXOgxJWrTLL7/8X6tq3UrHMU6W2ZJWq/nK7DVb0V6/fj0bN25c6TAkadGS/H8rHcO4WWZLWq3mK7PtOiJJkiSNgBVtSZIkaQSsaEuSJEkjYEVbkiRJGgEr2pIkSdIIWNGWJEmSRsCKtiRJkjQCVrQlSZKkEbCiLUmSJI2AFW1pQOuP/cT9D2m1SvL+JLcnuabPujckqSQ79aQdl2RzkuuTHNiTvm+Sq9u6k5OkpT88yYdb+qVJ1o/ljUkaiN9j42VFW5Kmy2nAQbMTk+wGPB/4dk/aXsDhwN4tz7uTbNNWnwIcDezZHjP7PAr4XlX9DPAO4KSRvAtJWgW2XekApNWotzXgphNfvIKRSItTVV+co5X5HcCfAOf2pB0CnFVV9wA3JtkM7JfkJmD7qroYIMkZwKHA+S3P8S3/R4C/TpKqquG/G0lL5ffYeNiiLUlTLsnBwHeq6muzVu0C3NzzektL26Utz05/UJ6quhf4AfC4OY57dJKNSTbecccdy34fkjRpbNGW5jFIP7aZbWwR0GqU5JHAm4AX9FvdJ63mSZ8vz9aJVacCpwJs2LDBFm9Ja44t2pI03Z4E7AF8rXUJ2RW4IslP0rVU79az7a7ALS191z7p9OZJsi3wE8B3Rxi/JE0sW7SlZrn91ezvptWoqq4GHj/zulW2N1TVvyY5D/hQkrcDT6S76fGyqrovyd1J9gcuBY4A3tV2cR5wJHAx8DLgc/bPljStbNGWpCmS5Ey6SvBTkmxJctRc21bVJuBs4FrgU8AxVXVfW/1q4L3AZuCbdDdCArwPeFy7cfIPgWNH8kYkaRWwRVuSpkhVvXyB9etnvT4BOKHPdhuBffqk/ztw2PKilKS1YWQt2kkekeSyJF9LsinJn7X0HZNckOSG9rxDT55FTYwgSZIkTapRtmjfA/znqvphkocCX0pyPvBS4MKqOjHJsXQ/K75x1sQITwQ+m+TJ7WfKmYkRLgE+STcxwvlbH1IajuXOmjVXfvtuS5I0PUbWol2dH7aXD22PopvM4PSWfjrdJAfQMzFCVd1I1+9vvyQ70yZGaDfUnNGTR1pVnPpWkqTpMdKbIZNsk+RK4Hbggqq6FHhCVd0K0J5n7nZfysQIkiRJ0kQaaUW7qu6rqqfTjbG6X5KtbpzpsZSJER68A2cZkyRJ0oQYy/B+VfV94CK6vtW3te4gtOfb22ZLmRhh9nFOraoNVbVh3bp1w3wLkiRJ0qKM7GbIJOuAH1fV95NsBzwPOIkHJjM4sT2f27IsZWIEaVnsLy1JkkZllKOO7AycnmQbupbzs6vq40kuBs5ukyR8mzbealVtSjIzMcK9bD0xwmnAdnSjjTjiiCRJkibayCraVXUV8Iw+6XcCB8yRZ1ETI0iSJEmTypkhNXXsLiJJksZhLDdDSpIkSdPGirYkSZI0Ala0JUmSpBGwj7a0Anr7id904otXMBJJkjQqtmhLkiRJI2BFW5IkSRoBK9qSJEnSCFjRliRJkkbAmyE1NZyoRpIkjZMt2pIkSdIIWNGWpCmS5P1Jbk9yTU/aW5N8PclVSc5J8tiedccl2Zzk+iQH9qTvm+Tqtu7kJGnpD0/y4ZZ+aZL143x/kjRJrGhL0nQ5DThoVtoFwD5V9VTgG8BxAEn2Ag4H9m553p1km5bnFOBoYM/2mNnnUcD3qupngHcAJ43snUjShLOiLUlTpKq+CHx3Vtpnqure9vISYNe2fAhwVlXdU1U3ApuB/ZLsDGxfVRdXVQFnAIf25Dm9LX8EOGCmtVuSpo0VbUlSr1cC57flXYCbe9ZtaWm7tOXZ6Q/K0yrvPwAe1+9ASY5OsjHJxjvuuGNob0CSJoUVbUkSAEneBNwLfHAmqc9mNU/6fHm2Tqw6tao2VNWGdevWLTZcSZp4Du+nNc0h/aTBJDkS+FXggNYdBLqW6t16NtsVuKWl79onvTfPliTbAj/BrK4qkjQtbNGWpCmX5CDgjcDBVfV/eladBxzeRhLZg+6mx8uq6lbg7iT7t/7XRwDn9uQ5si2/DPhcT8VdkqaKLdqSNEWSnAk8B9gpyRbgzXSjjDwcuKDdt3hJVb2qqjYlORu4lq5LyTFVdV/b1avpRjDZjq5P90y/7vcBH0iyma4l+/BxvC9JmkRWtCVpilTVy/skv2+e7U8ATuiTvhHYp0/6vwOHLSdGSVorrGhLK6y3H/lNJ754BSORJEnDZB9tSZIkaQSsaEuSJEkjYEVbkiRJGoGRVbST7Jbk80muS7Ipyeta+vFJvpPkyvZ4UU+e45JsTnJ9kgN70vdNcnVbd7LT+UqSJGnSjfJmyHuBP6qqK5I8Brg8yQVt3Tuq6m29GyfZi24YqL2BJwKfTfLkNpTUKcDRwCXAJ4GDeGAoKUmSJGnijKxFu6puraor2vLdwHXALvNkOQQ4q6ruqaobgc3Afkl2BravqovbpAdnAIeOKm5JkiRpGMYyvF+S9cAzgEuBZwOvSXIEsJGu1ft7dJXwS3qybWlpP27Ls9P7HedoupZvdt999+G+Ca0aq3nadYf6kyRp7Rj5zZBJHg18FHh9Vd1F1w3kScDTgVuBv5rZtE/2mid968SqU6tqQ1VtWLdu3XJDlyRJkpZspC3aSR5KV8n+YFV9DKCqbutZ/3fAx9vLLcBuPdl3BW5p6bv2SZfut5pbsSVJ0to0ylFHQjet73VV9fae9J17NnsJcE1bPg84PMnDk+wB7AlcVlW3Ancn2b/t8wjg3FHFLUmSJA3DKFu0nw38DnB1kitb2p8CL0/ydLruHzcBvwdQVZuSnA1cSzdiyTFtxBGAVwOnAdvRjTbiiCOSJEmaaCOraFfVl+jfv/qT8+Q5ATihT/pGYJ/hRSdJkiSN1lhGHZG0eI5AIknS6uYU7JIkSdIIWNGWJEmSRsCKtiRJkjQCVrQlSZKkEbCiLUmSJI2AFW1JkiRpBKxoS9IUSfL+JLcnuaYnbcckFyS5oT3v0LPuuCSbk1yf5MCe9H2TXN3Wndxm7qXN7vvhln5pkvVjfYOSNEGsaGvVWn/sJ+5/SBrYacBBs9KOBS6sqj2BC9trkuwFHA7s3fK8O8k2Lc8pwNHAnu0xs8+jgO9V1c8A7wBOGtk7kaQJZ0VbkqZIVX0R+O6s5EOA09vy6cChPelnVdU9VXUjsBnYL8nOwPZVdXFVFXDGrDwz+/oIcMBMa7ckTRsr2pKkJ1TVrQDt+fEtfRfg5p7ttrS0Xdry7PQH5amqe4EfAI/rd9AkRyfZmGTjHXfcMaS3IkmTw4q2tArYRUYrpF9LdM2TPl+erROrTq2qDVW1Yd26dUsMUZImlxVtSdJtrTsI7fn2lr4F2K1nu12BW1r6rn3SH5QnybbAT7B1VxVJmgpWtCVJ5wFHtuUjgXN70g9vI4nsQXfT42Wte8ndSfZv/a+PmJVnZl8vAz7X+nFL0tTZdqUDkCSNT5IzgecAOyXZArwZOBE4O8lRwLeBwwCqalOSs4FrgXuBY6rqvrarV9ONYLIdcH57ALwP+ECSzXQt2YeP4W1J0kSyoi1JU6SqXj7HqgPm2P4E4IQ+6RuBffqk/zutoi5J086uI5IkSdIIWNGWJEmSRsCKtiRJkjQCVrQlSZKkEbCiLUmSJI2Ao45Iq0jv7JA3nfjiFYxEkiQtxBZtSZIkaQRGVtFOsluSzye5LsmmJK9r6TsmuSDJDe15h548xyXZnOT6JAf2pO+b5Oq27uQ2E5kkSZI0sUbZon0v8EdV9XPA/sAxSfYCjgUurKo9gQvba9q6w4G9gYOAdyfZpu3rFOBouul/92zrJUmSpIk1sj7aVXUrcGtbvjvJdcAuwCF00/8CnA5cBLyxpZ9VVfcAN7bpe/dLchOwfVVdDJDkDOBQHpjuV5IkSUvk/T+jM3BFu7UuP6E3T1V9e8C864FnAJcCT2iVcKrq1iSPb5vtAlzSk21LS/txW56d3u84R9O1fLP77rsPEpokrWrLKZslSaM1UEU7yWuBNwO3Af/Rkgt46gB5Hw18FHh9Vd01T/fqfitqnvStE6tOBU4F2LBhQ99ttPr1/uctTbPllM2Spoffmytn0Bbt1wFPqao7F7PzJA+lq2R/sKo+1pJvS7Jza83eGbi9pW8BduvJvitwS0vftU+6JE27JZXNkqTxGLSifTPwg8XsuI0M8j7guqp6e8+q84AjgRPb87k96R9K8nbgiXQ3PV5WVfcluTvJ/nRdT44A3rWYWLT6+d+41Neiy2ZJ0vgMWtH+FnBRkk8A98wkzqpAz/Zs4HeAq5Nc2dL+lK6CfXaSo4BvA4e1fW1KcjZwLd2IJcdU1X0t36uB04Dt6G6C9EZISVpa2SxJGpNBK9rfbo+HtceCqupL9O9fDXDAHHlOAE7ok74R2GegSCVpeiy6bJYkjc9AFe2q+rNRByJJWhzLZkmabPNWtJP8j6p6fZL/RZ+RPqrq4JFFJmlejns6vSybJWl1WKhF+wPt+W2jDkSSNDDLZklaBeataFfV5e35C0keBvwsXevJ9VX1ozHEJ0maxbJZklaHhwyyUZIXA98ETgb+Gtic5IWjDEySNL9hl81J/iDJpiTXJDkzySOS7JjkgiQ3tOcderY/LsnmJNcnObAnfd8kV7d1J2eemcokaS0bqKIN/BXw3Kp6TlX9J+C5wDtGF5YkaQBDK5uT7AL8PrChqvYBtgEOB44FLqyqPYEL22uS7NXW7w0cBLy7TQcPcApwNN18CHu29ZI0dQataN9eVZt7Xn+LB2Z0lCStjGGXzdsC2yXZFngk3Sy8hwCnt/WnA4e25UOAs6rqnqq6EdgM7Ndm/N2+qi6uqgLO6MkjSVNloVFHXtoWNyX5JHA2XT/Aw4CvjDg2TTlngxycI5BMl1GUzVX1nSRvoxuX+9+Az1TVZ5I8oapubdvcmuTxLcsuwCU9u9jS0n7clmenS9LUWWjUkV/rWb4N+E9t+Q5gh603lySNwdDL5tb3+hBgD+D7wD8k+e35svRJq3nS+x3zaLouJuy+++6LCVeSVoWFKtoXAJ+uqjvHEYwkaSCjKJufB9xYVXcAJPkY8CzgtiQ7t9bsnXmga8oWYLee/LvSdTXZ0pZnp2+lqk4FTgXYsGFD38q4JK1mC/XR3p2uVeOfkhyf5Be8e1ySVtwoyuZvA/sneWTb1wHAdcB5wJFtmyOBc9vyecDhSR6eZA+6mx4va91M7k6yf9vPET15JGmqLDSO9onAiUkeQ9fa8UrgPUmuAz5F16Jy2+jDlCTNGEXZXFWXJvkIcAVwL/BVutbmRwNnJzmKrjJ+WNt+U5KzgWvb9sdU1X1td68GTgO2A85vD0maOgt1HQGgqu4GzmmPmWGdXkh3N/mB82SVJI3IsMvmqnoz8OZZyffQtW732/4E4IQ+6RuBfRZ7fElaawadsObC3tdVdS3woqqyki1JK8SyWZIm20LD+z2CbizVndod6TN9ALcHnjji2CRJfVg2S9LqsFDXkd8DXk9XcF/OA4X5XcDfjC4sSdI8LJslaRVY6GbIdwLvTPLaqnrXmGLSFHOSGmlhls2StDoMejPku5I8C1jfm6eqzhhRXJKkBVg2S9JkG6iineQDwJOAK4GZ4ZuK7s52SdIKsGyWpMk2UEUb2ADsVVXO3CVJk8OyWZIm2EDD+wHXAD85ykAkDcf6Yz9hX/fpYdksSRNs0BbtnYBrk1xGN3kBAFV18EiikiQNwrJZkibYoBXt40cZhCRpSY5f6QAkSXMbdNSRL4w6EEnS4lg2S9JkG3QK9ruT3NUe/57kviR3LZDn/UluT3JNT9rxSb6T5Mr2eFHPuuOSbE5yfZIDe9L3TXJ1W3dyksw+liRNo6WUzZKk8Rm0Rfsxva+THArst0C204C/Zuthpt5RVW+btb+9gMOBvelmOvtskidX1X3AKcDRwCXAJ4GDgPMHiVuS1rIlls2SpDEZdNSRB6mqfwT+8wLbfBH47oC7PAQ4q6ruqaobgc3Afkl2Bravqovb8FVnAIcuJWZJWusGKZslSeMz6IQ1L+15+RC6sVuXOm7ra5IcAWwE/qiqvgfsQtdiPWNLS/txW56dPlecR9O1frP77rsvMTytBIejkxZvyGWzJGnIBh115Nd6lu8FbqJrhV6sU4C30H0RvAX4K+CVQL9+1zVPel9VdSpwKsCGDRv8spG01g2rbJYkjcCgfbR/dxgHq6rbZpaT/B3w8fZyC7Bbz6a7Are09F37pEvS1BtW2SxJGo1BRx3ZNck5bRSR25J8NMmuC+fcaj8797x8Cd2sZgDnAYcneXiSPYA9gcuq6lbg7iT7t9FGjgDOXexxJWktGlbZLEkajUFvhvx7usrwE+n6SP+vljanJGcCFwNPSbIlyVHAX7ah+q4Cngv8AUBVbQLOBq4FPgUc00YcAXg18F66GyS/iSOOSNKMRZfNkqTxGbSP9rqq6i28T0vy+vkyVNXL+yS/b57tTwBO6JO+EdhnwDglaZosumyWJI3PoC3a/5rkt5Ns0x6/Ddw5ysAkLc/6Yz9x/0Nr1lDL5iSPTfKRJF9Pcl2SX0yyY5ILktzQnnfo2d6JxiRpHoNWtF8J/AbwL8CtwMsAb8KRpJU17LL5ncCnqupngacB1wHHAhdW1Z7Ahe317InGDgLenWSbtp+Zicb2bI+DlhGTJK1ag3YdeQtwZBvzmiQ7Am+jK+SlJbGlVVq2oZXNSbYHfgV4BUBV/Qj4UZJDgOe0zU4HLgLeSM9EY8CNSWYmGruJNtFY2+/MRGPeXyNp6gzaov3UmYIcoKq+CzxjNCFJkgY0zLL5p4E7gL9P8tUk703yKOAJbQQo2vPj2/a7ADf35J+ZUGwXFjHRmCStZYO2aD8kyQ6zWk0GzStphfX+enDTiS9ewUg0ZMMsm7cFngm8tqouTfJOWjeROSx7ojFn85W01g1aIP8V8OUkH6ErMH+DPiOESJLGaphl8xZgS1Vd2l5/hK6ifVuSnavq1jYXwu092y9rojFn85W01g3UdaSqzgB+HbiN7qfFl1bVB0YZmCRpfsMsm6vqX4CbkzylJR1AN7fBecCRLe1IHpg0zInGJGkBA//EWFXX0hW6kqQJMeSy+bXAB5M8DPgW3QgmDwHObpOOfRs4rB13U5KZicbuZeuJxk4DtqO7CdIbISVNJftZS5IAqKorgQ19Vh0wx/ZONCZJ87CiLUmSJMCb54fNirYkSdIa41wVk2HQcbQlSZIkLYIVbUmSJGkE7DqisfKnLEmSNC1s0ZYkSZJGwIq2JEmSNAJ2HZGmjEM3SZI0HrZoS5IkSSNgRVuSJEkaASvakiRJ0ghY0ZYkSZJGwIq2JEmSNAKOOqKRc5KayTXz2Tj6iCRJwzeyFu0k709ye5JretJ2THJBkhva8w49645LsjnJ9UkO7EnfN8nVbd3JSTKqmCVJkqRhGWXXkdOAg2alHQtcWFV7Ahe21yTZCzgc2LvleXeSbVqeU4CjgT3bY/Y+JUmSpIkzsop2VX0R+O6s5EOA09vy6cChPelnVdU9VXUjsBnYL8nOwPZVdXFVFXBGTx5JkiRpYo37ZsgnVNWtAO358S19F+Dmnu22tLRd2vLs9L6SHJ1kY5KNd9xxx1ADlyRJkhZjUkYd6dfvuuZJ76uqTq2qDVW1Yd26dUMLTpIkSVqscVe0b2vdQWjPt7f0LcBuPdvtCtzS0nftky5JkiRNtHFXtM8DjmzLRwLn9qQfnuThSfagu+nxsta95O4k+7fRRo7oyaMJt/7YTzi0nyRJmlqjHN7vTOBi4ClJtiQ5CjgReH6SG4Dnt9dU1SbgbOBa4FPAMVV1X9vVq4H30t0g+U3g/FHFLEnTLsk2Sb6a5OPttcOyStISjWzCmqp6+RyrDphj+xOAE/qkbwT2GWJokqS5vQ64Dti+vZ4ZlvXEJMe212+cNSzrE4HPJnlyaySZGZb1EuCTdMOy2kgiaepMys2QklbQTDcfu/pMtyS7Ai+m+xVxhsOyStISWdGWJM34H8CfAP/RkzayYVkdklXSWmdFW5JEkl8Fbq+qywfN0idtUcOyOiSrpLVuZH20Ja1Ovd1HbjrxxSsYicbs2cDBSV4EPALYPsn/pA3LWlW3OiyrJC2OFW0NlX18pdWpqo4DjgNI8hzgDVX120neSjcc64lsPSzrh5K8ne5myJlhWe9LcneS/YFL6YZlfdc434skTQor2pKk+ZwInN2GaP02cBh0w7ImmRmW9V62Hpb1NGA7utFGHHFEGgMbuyaPFW1J0oNU1UXARW35ThyWVZpKMxV3uxEunTdDSpIkSSNgRVuSJEkaASvakiRJ0gjYR1vL5s0XkiRJW7NFW5IkSRoBK9qSJEnSCNh1RNKcnCVSkqSls0VbkiRJGgEr2pIkSdII2HVES+JII5IkSfOzRVuSJEkaASvakiRJ0gjYdUTSQByBRJKkxbFFW5IkSRoBW7QlSZJWKQcnmGxWtCVJkjQnuw4u3YpUtJPcBNwN3AfcW1UbkuwIfBhYD9wE/EZVfa9tfxxwVNv+96vq0ysQ9tTzv2bNmLkWLHAlSZrbSvbRfm5VPb2qNrTXxwIXVtWewIXtNUn2Ag4H9gYOAt6dZJuVCFiSJEka1CTdDHkIcHpbPh04tCf9rKq6p6puBDYD+40/PEmSJGlwK1XRLuAzSS5PcnRLe0JV3QrQnh/f0ncBbu7Ju6WlbSXJ0Uk2Jtl4xx13jCh0SZIkaWErVdF+dlU9E3ghcEySX5ln2/RJq34bVtWpVbWhqjasW7duGHFK0lRIsluSzye5LsmmJK9r6TsmuSDJDe15h548xyXZnOT6JAf2pO+b5Oq27uQk/cpxSVrzVqSiXVW3tOfbgXPouoLclmRngPZ8e9t8C7BbT/ZdgVvGF60kTYV7gT+qqp8D9qdrBNmLpd0/cwpwNLBnexw0zjciSZNi7KOOJHkU8JCqurstvwD4c+A84EjgxPZ8bstyHvChJG8HnkhXaF827rglbc0hn9aO1mVvpvve3Umuo+umdwjwnLbZ6cBFwBvpuX8GuDHJZmC/NqrU9lV1MUCSM+juuTl/XO9FmgaOBLY6rMTwfk8Azmm/JG4LfKiqPpXkK8DZSY4Cvg0cBlBVm5KcDVxL1+JyTFXdtwJxS9JUSLIeeAZwKbPun0nSe//MJT3ZZu6f+XFbnp3e7zhH07V8s/vuuw/xHUgaFRtYFmfsFe2q+hbwtD7pdwIHzJHnBOCEEYemOfhfszQ9kjwa+Cjw+qq6a57u1XPdP7Oo+2qAUwE2bNjQdxtJWs0maXg/SdIKSvJQukr2B6vqYy15sffPbGnLs9Mlaeo4Bbv6shVbi+XPiatbGxnkfcB1VfX2nlWLun+mqu5LcneS/em6nhwBvGtMb0OSJooVbUkSwLOB3wGuTnJlS/tTugr2Yu+feTVwGrAd3U2Q3ggpaSpZ0ZYkUVVfon//aljk/TNVtRHYZ3jRSdLqZEVbkiRpFbBb5+rjzZCSJEnSCNiirfv5n7KGxRsjJWnts6xfmC3akkZq/bGf8J84SdJUskV7ylkBkiRJGg0r2pLGwp8YJWnxbBBb3ew6IkmSpGWxm2B/VrQlSZKkEbDryJTyv05JkqTRsqItSZI0QVZzY5j34zyYFe0pspr/cCVJklYbK9qSxs4WD0na2lprELOst6ItaYVZEEuS1ior2mvQWvuPWJKktWpavrOntVHFirakiTFTEE9TISxp+kxL5VpWtNcU/3AlSZpMfkc/oN+5WKsNLFa0Vzn/cLUWTetPjJI0rdZquW9FW9JEW6uFr6S1y0aw5VlL5b4V7VXIP2BJklae38ejt9q7mVjRXiX8Y5ZWf4ErafXye3hyDPJZTMp3w6qpaCc5CHgnsA3w3qo6cYVDGhn/mKXBzfX3MimF7LSapjJbq4vfsdNhMZ/zKL8vVkVFO8k2wN8Azwe2AF9Jcl5VXbuykQ2Pf/jScK2lPn6rzTSU2VqeQf4+/V7UuIxyaNlVUdEG9gM2V9W3AJKcBRwCTEShbWEgTbal/o32K3TnqiA4BviDTHSZDYv7vCzjR8vzq7VstVS0dwFu7nm9BfiF2RslORo4ur38YZLrl3CsnYB/XUK+YZuUOGByYpmUOGByYpmUOGANxpKTFr9+VtpS4/ipJeSZJKumzF7oMx5XHENmLFublDhgcmKZlDhgQmLJScMvs1dLRTt90mqrhKpTgVOXdaBkY1VtWM4+hmFS4oDJiWVS4oDJiWVS4gBjmeQ4VoBl9goylsmNAyYnlkmJAyYnllHE8ZBh7myEtgC79bzeFbhlhWKRJM3PMluSWD0V7a8AeybZI8nDgMOB81Y4JklSf5bZksQq6TpSVfcmeQ3wabqhot5fVZtGdLhl/Yw5RJMSB0xOLJMSB0xOLJMSBxhLP5MSx1hZZq84Y9napMQBkxPLpMQBkxPL0ONI1Vbd5iRJkiQt02rpOiJJkiStKla0JUmSpBGwog0keWuSrye5Ksk5SR7bs+64JJuTXJ/kwDHEcliSTUn+I8mGnvT1Sf4tyZXt8Z6ViKOtG+s5mXXs45N8p+c8vGjMxz+ove/NSY4d57H7xHJTkqvbedg45mO/P8ntSa7pSdsxyQVJbmjPO6xQHCtyjSTZLcnnk1zX/nZe19LHfl7WmkHP4Vx/E8P6DAbZz1zXQVu3rGtzofInnZPb+quSPHPQvIs1QCy/1WK4KsmXkzytZ91Qy64BYnlOkh/0nPf/NmjeIcfxxz0xXJPkviQ7tnVDOyf9ysVZ68d5nSwUy1iukwHiGN01UlVT/wBeAGzblk8CTmrLewFfAx4O7AF8E9hmxLH8HPAU4CJgQ0/6euCaMZ6TueIY+zmZFdfxwBtW6DrZpr3fnwYe1s7DXisRS4vnJmCnFTr2rwDP7L0mgb8Ejm3Lx878Ha1AHCtyjQA7A89sy48BvtH+XsZ+XtbaY9BzONffxLA+g0H2M9d10F4v+docpPwBXgScTzeO+f7ApYPmHUEszwJ2aMsvnIllvs9phLE8B/j4UvIOM45Z2/8a8LkRnZOtysWVuE4GjGVc18lCcYzsGrFFG6iqz1TVve3lJXRjvkI3ZfBZVXVPVd0IbKabWniUsVxXVUuZHW1ccYz9nEyQ+6eVrqofATPTSk+dqvoi8N1ZyYcAp7fl04FDVyiOFVFVt1bVFW35buA6uhkSx35e1qDlnsNhfQYL7mee62C5Bil/DgHOqM4lwGOT7Dxg3qHGUlVfrqrvtZe936vDtpz3Nszzsth9vRw4c4nHmtcA5eK4rpMFYxnXdbKM74plnxMr2lt7Jd1/etB/GuFhFJhLtUeSryb5QpJfXqEYJuGcvKb9zPT+pf4EvEST8N57FfCZJJenm8p6pT2hqm6FrrIBPH4FY1mpawTounoBzwAuZbLOy2o16Dmc629iWJ/BovYz6zqYsdRrc5DyZ65thl12LXZ/R/HA9yoMt+waNJZfTPK1JOcn2XuReYcZB0keCRwEfLQneZzl+biuk8Ua5XUyiJFcI6tiHO1hSPJZ4Cf7rHpTVZ3btnkTcC/wwZlsfbZf9niIg8TSx63A7lV1Z5J9gX9MsndV3TXmOEZyTh50gHniAk4B3tKO+Rbgr+j+ORqHkb/3RXp2Vd2S5PHABUm+3v5rn3YreY2Q5NF0X6Cvr6q7kn6XjWZb4O9+UMv+mxhSHFtdBy15OdfmIOXPXNsMu+waeH9JnktXgfqlnuRhll2DxHIF8FNV9cN0/eL/EdhzwLzDjGPGrwH/XFW9LazjLM/HdZ0MbAzXyUJGdo1MTUW7qp433/okRwK/ChxQrWMOI5pGeKFY5shzD3BPW748yTeBJwNLvkFgKXEwhqmVB40ryd8BHx/msRcwUdNKV9Ut7fn2JOfQ/cS1khXt25LsXFW3tp8hb1+JIKrqtpnlcV8jSR5KV7n6YFV9rCVPxHmZdPP93ScZ6BzO8zcx8GcwjDjmuA6We20OUv7Mtc3DBsi7GAOVhUmeCrwXeGFV3TmTPuSya8FYehukquqTSd6dZKdB38ew4uhxOLO6jYy5PB/XdTKQMV0n8xrlNWLXEbo7SoE3AgdX1f/pWXUecHiShyfZg+6/m8tWKMZ1SbZpyz/dYvnWCoSyouekfbnNeAnQ9w7iEZmYaaWTPCrJY2aW6W7oHee56Oc84Mi2fCQw168iI7VS10i6puv3AddV1dt7Vk3EeVnlFjyHC/xNDOszGCSOua6D5V6bg5Q/5wFHpLM/8IPWxWXYZdeC+0uyO/Ax4Heq6hs96cMuuwaJ5Sfb50KS/ejqPncOkneYcbTj/wTwn+i5dlagPB/XdbKgMV4nC8UxumukhnA352p/0N3QdzNwZXu8p2fdm+juOL2e7r+tUcfyErr/oO4BbgM+3dJ/HdhEd8frFcCvrUQcK3FOZsX1AeBq4Kp2se885uO/iG4UgW/SdbFZqWv2p9u18LV2XYw1FrrWmFuBH7fr5CjgccCFwA3teccVimNFrhG6nzyrHXemLHnRSpyXtfaY6xwCTwQ+2Zbn/JsY1mcwYBx9r4O2blnXZr/yB3gV8Kq2HOBv2vqrefCIUUMtuwaI5b3A93rOwcaFPqcRxvIaHvj+vAR41ijOy0JxtNevoBtQoDffUM8J/cvFlbpOFoplLNfJAHGM7BpxCnZJkiRpBOw6IkmSJI2AFW1JkiRpBKxoS5IkSSNgRVuSJEkaASvakiRJ0ghY0da8kpyW5GVt+b1J9hrCPjckOXmBbZ7eZmcadJ+PS3Jle/xLku/0vH7YEGJ+a5JN7XldkkuTfDXJLye5qQ1sT5IvL/dYbT+vSnLEAtscupjPI8mBPefkh0mub8tnzNruOUl+kOSTPWl7Jvl4km+mmw7380l+ZZ5jPSrJnW3M2N70f0zyG0l+M8nmJOOccEiaKmup/E7yt0mePc8+frZt/9UkT0ry+0muS/LBJK9I8tdtuwXL1kXEPW95n+SxSf7vRe7znPY+NrdyeOY8PGvWdhe1MvzgnrQ/TPL1JFenm0r87ekmT5rrWMcn+YtZaU9Pcl1b/nz7rtiwmPegWZY7RqKPtf0ATgNetgLHfQXw10vMezzwhiHHcxfw8LZ8OHB6z7qbgJ1W02cDXETP2Kmz1j0H+HjP60fQjSF6cE/aPsArFjjGmcCRPa9/AvhX4JH9juPDh4/hPtZS+U03xvI28+Q7FvizntdfB/ZYbjzLPA/rgWuWmHfe8nF2GU43JvSngMe21w9r52T7efbxFOBbs9JOBP7fuY7jY/EPW7SnTPuP95r2eH1LW9/+8/+71mr7mSTb9cl70cx/tu2/3BPaf82XJHlCS1+X5KNJvtIeW7VAtBbTj7flRyV5f9v2q0kOaS0Yfw78ZvtP/jdn5X9FknOTfKr9R//mIZ2bpGuxvqa1CPxmSz8PeBRwaZI3An8JvKjFtt2sffyw5z1elOQjrYXhg8n9s07tm+QL6VqGP50HzxY3s5/jk7yhLT+pvdfLk/xTa7l5FnAw8NYWx5Nm5T8tyXva9t9I8qvLODW/BVxcVffPhlVV11TVae1YW32GbbMz6f4pmfES4FP14NlXJQ1oWsvvJD8HfKOq7kvX4npJkqvStf7ukK71/PXAf0nXCvseuglPzkvyB7P21Vu2XpTkpCSXtXLyl1v6Nu274CvtOL83R1w/7Fn+457t/6wlnwg8qZ2Ht87Ku759N5ze8nwkySMXOhfzeBPw6qr6PkBV/aiqTqw2tXiSFyS5OMkVSf4hyaOr6nrg+0l+oWc/vwGctYw4NIsV7SmSZF/gd4FfAPYH/muSZ7TVewJ/U1V7A9+nm4lyPo8CLqmqpwFfBP5rS38n8I6q+vm2j/cusJ83AZ9r2z8XeCvwUOC/AR+uqqdX1Yf75NuPrgL4dOCwDOenrZe2/T0NeB5dJXbnqjoY+LcWy0mzYvu3efb3DLrCfy+6Qv/Z6X7GexddK9O+wPuBExaI61TgtW37NwDvrqov080s98ctjm/2ybeebqrfFwPvSfKIBc9Af3vTzUY6l60+w3RT5n4K2DfJ49p2h9NVviUt0pSX3y+kK08AzgDeWFVPpZvV8M1V9UngPS3251bVq4BbgOdW1TsW2Pe2VbUfXVk9U+k/im5a8p8Hfp7uXO8x1w6SvIDuM9ivvad903WtOxb4ZjsPf9wn61OAU9t7uQtYVDeTnuM/Bnh0Vd04x/qdgP8HeF5VPRPYCPxhW31/g0i66djvrKoblhKH+tt2pQPQWP0ScE5V/W+AJB8DfpmuwnZjVV3ZtrucrpI2nx8BM/1rLwee35afB+zVGm8Btk/ymKq6e479vAA4eKaFga6bwu4DvJcLqurOnvfxS3SFx3L8EnBmVd0H3JbkC3SF7HnzZ5vTZVW1pcV4Jd05/T5dt4sL2jnahm5a2L6SPBp4FvAPPef04QMe/+yq+g/ghiTfAn6W7ufXZUlyDt2Xyjeq6qXM8RlW1XXpfg14WZKP0n0BfWa5x5em1DSX3wcCv5vuno/HVtUXWvrpwD8McLz5fKw99563FwBPTevfTtftbU+gb0W2bf8C4Kvt9aPb9t9e4Ng3V9U/t+X/Cfw+8LbFBN8EuH+a7yQHAicBjwX+L2BHugaff26f7cOAi9vmZwFfTvJH2BgyEla0p0vmWXdPz/J9wFY/Pc7y46qa+cO+jweupYcAv7hAS+/smH69/YT1QOKDf8rqpxZ43f9gyUt4oNXiv1RVb+E+3/lZitnndNt2jE1V9YsD7uMhwPer6ulLOP6SzlEfm4D7b3ysqpe0FqiZL4S+n2FzJl1LSoBzq+rHS4xBmnZTWX637hSPrapbMuvm6iGZOXe95yF0vyJ+esB9BPiLqvrbByUm6xfIN5QyuqruSvK/k+xRVTe2uD/duvg8rMV3QVW9vE/em5PcRPfr568Dg343aUB2HZkuXwQOTfLI9tP+S4B/GvIxPgO8ZuZFkqcvsP2ngdcm9/dfnvkp9G7gMfPke36SHdP1RTwU+Od5tr1fVZ3TfsZ7+qxKNnTn5zdb/7x1dJXLywbZ7yJcD6xL8osASR6aZO954r0LuDHJYW37JHlaW73QOTosyUPS9d/+6XbspfgQXbeXg3vSevsSzvUZAnyermXnGGwpkZZjWsvv59KVI1TVD4DvzfSlBn4H+MJcGZfh08CrW1c/kjy5nfP5tn9l+wWSJLskeTwLn4fdZ74LgJcDX1pGzH8BnJLksS2G0P3CAHAJXRn+M23dI5M8uSfvmcA76Lq5bFlGDOrDivYUqaor6O5Cvwy4FHhvVX113kyL9/vAhnZzx7V0d0L3Dac9v4WuT99VSa5pr6ErWPdKn5tpmi8BH6DrCvHRPpXmpTgHuAr4GvA54E+q6l+GsN/7VdWPgJcBJyX5Gl38z5pr8/b8W8BRbftNwMzNhmcBf5w2nFWf/NfTfQmdD7yqqv59iTH/G/CrwKuSfCvJxXSt1P+9bTLXZ0jruvJR4HF0FQVJSzDF5Xdv/2yAI+nuA7mKrjvany/4rhbvvcC1wBXtff0t/XsAFEBVfYauQeLiJFcDHwEe07rH/HO6m1ff2if/dcCR7b3sCJyyjJhPAT5Ld9P+VXT/vHwV+GpV3UE38sqZbd0ldF0JZ/wD3b043gQ5Anng1yNpPJL8Ot1QcUcuMf8r6IYbes1C265WSd4FXFFVf7/E/KfRDQ31kSXkfQ7d8FrLGalkYo4jaXjGXX4nuQL4hUnrdpbuJu8rquqnlph/PV0Zvc8S819EV34Oo5FpxY+zltmirbFq3Q9OoGshUB9J3kI3ssBSb8Jcrh8B+6Rnwppha61c7wa+N6pjSBqulSi/q+qZE1jJfiLdzYRLuXFxWL4LnDarS99QJfk8XbfDiTr/q40t2pIkSdII2KItSZIkjYAVbUmSJGkErGhLkiRJI2BFW5IkSRoBK9qSJEnSCPz/1v0C12GeZzsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 864x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "standard deviation of distribution = 5.0 GeV\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Now we plot the online vs offline response.\n",
+    "## This should have a spread determined by our sigma set above.\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2)\n",
+    "fig.set_size_inches(12,4)\n",
+    "\n",
+    "pt_ratio = online_jets_pt/offline_jets_pt\n",
+    "pt_diff = online_jets_pt-offline_jets_pt\n",
+    "\n",
+    "ax1.hist(pt_diff, bins=100, range=[-20,20])\n",
+    "ax1.set_ylabel(f\"count/bin\")\n",
+    "ax1.set_xlabel(\"online jet pT - offline jet pT [GeV]\")\n",
+    "ax2.hist(pt_ratio, bins=100, range=[-0.5,1.5])\n",
+    "ax2.set_ylabel(f\"count/bin\")\n",
+    "ax2.set_xlabel(\"online jet pT/offline jet pT [GeV]\")\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"standard deviation of distribution = %.1f GeV\"%(pt_diff.std()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "40027bcd",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 486
+    },
+    "id": "40027bcd",
+    "outputId": "896e320f-9325-4081-83d5-d84a347dec5e"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Minimum offline jet pT:  133.1700364964153\n",
+      "Maximum offline jet pT:  1492.4783182402612\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEGCAYAAACUzrmNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAXOUlEQVR4nO3dfbRldX3f8fdHREWFADKQcQYcYlCDNktlghiylKgVJEYwic1YjdOlCakhrS5rAiTGQFeopKbWWpUlqRasCiU+FOISEanUSFEyPMmTE8ZChTBl0FQZ7JLw8O0f+zfheLn37HNn5jzce9+vtc46e//23md/+S1mvvN72L+dqkKSpGEeN+0AJEmzz2QhSeplspAk9TJZSJJ6mSwkSb0eP+0AxuWAAw6odevWTTsMSVpSrrnmmu9W1aq55cs2Waxbt45NmzZNOwxJWlKS/O/5yu2GkiT1MllIknqZLCRJvUwWkqReJgtJUi+ThSSpl8lCktTLZCFJ6mWykCT1WrZPcO+K00+/suf40ROKRJJmgy0LSVIvk4UkqZfJQpLUy2QhSeplspAk9TJZSJJ6mSwkSb1MFpKkXiYLSVIvk4UkqZfJQpLUy2QhSeplspAk9TJZSJJ6mSwkSb18n8VOGHzfhe+2kLQS2LKQJPUyWUiSepksJEm9TBaSpF4mC0lSL5OFJKmXyUKS1MtkIUnqZbKQJPXyCe5dNPg0d7fvE92Slh9bFpKkXmNPFkn2SHJdks+3/f2TXJbktva938C5pyXZkmRzkmMHyo9IcmM79oEkGXfckqRHTaJl8Tbg1oH9U4HLq+ow4PK2T5LDgQ3Ac4HjgA8n2aNdczZwEnBY+xw3gbglSc1YxyySrAV+CTgTeEcrPgE4pm2fB1wBnNLKL6iqB4Dbk2wBjkxyB7BPVV3VfvPjwInAJeOMfWc5hiFpORp3y+L9wO8DjwyUHVRVWwHa94GtfA1w58B5d7WyNW17bvljJDkpyaYkm+69997d8h8gSRpjskjyamBbVV0z6iXzlNWQ8scWVp1TVeurav2qVatGvK0kqc84u6GOBl6T5HjgScA+ST4B3JNkdVVtTbIa2NbOvws4eOD6tcDdrXztPOWSpAkZW7KoqtOA0wCSHAO8s6remOS9wEbgrPZ9UbvkYuBTSd4HPJ1uIPvqqno4yfYkRwHfAN4E/Mdxxb27OYYhaTmYxkN5ZwEXJnkL8B3gdQBVdXOSC4FbgIeAk6vq4XbNW4Fzgb3oBrZncnBbkpariSSLqrqCbtYTVfU94OULnHcm3cypueWbgOeNL0JJ0jA+wS1J6mWykCT1MllIknqZLCRJvUwWkqReJgtJUi+ThSSpl8lCktTLZCFJ6mWykCT1MllIknqZLCRJvUwWkqReJgtJUq9pvM9iRfNlSJKWIlsWkqRetiymbLClYStD0qyyZSFJ6mWykCT1MllIknqZLCRJvUwWkqReJgtJUi+ThSSpl8lCktTLZCFJ6uUT3DPMdaQkzQpbFpKkXrYsZsjcloQkzYoFWxZJ9pxkIJKk2TWsG+pvk/x5kpclycQikiTNnGHJ4meATcAfAXcmeX+SF00mLEnSLFkwWVTV96rqI1X1i8CRwO3A+5N8O8mZE4tQkjR1I82Gqqq7gY8CZwPbgd8cZ1CSpNkyNFkkeVKS1yX5LPBt4OXAacDTJxGcJGk2DJsN9SngO8CvA58CnlFVG6vqkqp6uO+HW6K5OskNSW5OckYr3z/JZUlua9/7DVxzWpItSTYnOXag/IgkN7ZjH3DAXZIma9hzFpcCv11V23fytx8AXlZV97dpuF9LcgnwK8DlVXVWklOBU4FTkhwObACeS9dy+XKSZ7XEdDZwEvB14AvAccAlOxnXkuUT3ZKmZdgA93lVtT3JQUk+muSLAEkOT/KWvh+uzv1td8/2KeAE4LxWfh5wYts+Abigqh6oqtuBLcCRSVYD+1TVVVVVwMcHrpEkTcAoA9zn0rUyVrf9vwHePsqPJ9kjyfXANuCyqvoGcFBVbQVo3we209cAdw5cflcrW9O255bPd7+TkmxKsunee+8dJURJ0ghGSRYHVNWFwCMAVfUQ0Dtm0c59uKqeD6ylayU8b8jp841D1JDy+e53TlWtr6r1q1atGiVESdIIRkkWP0zyNNpf0EmOAn6wmJtU1feBK+jGGu5pXUu0723ttLuAgwcuWwvc3crXzlMuSZqQUZLFO4CLgWcmuZJuzOBf9F2UZFWSfdv2XsArgG+139rYTtsIXNS2LwY2JHlikkOBw4CrW1fV9iRHtVlQbxq4RpI0Ab2rzlbVtUleCjybrktoc1U9OMJvrwbOS7IHXVK6sKo+n+Qq4MI2SP4d4HXtPjcnuRC4BXgIOHlgiu5b6cZO9qKbBbXiZkJJ0jQtmCyS7EM3GH1bVT3UprbuBbwwyaVVdc+wH66qbwIvmKf8e3QP9813zZnAY5YSqapNwLDxDknSGA3rhvozYHAi/3uA9cBLgDPGGZQkabYM64b6OeC3B/a3V9W/BEjytbFGJUmaKcOSxePbQ3A7/MbA9r7jCUeL4RPdkiZlWDfUI0l+csdOVd0EkGQN7ZkLSdLKMCxZvBf4yyQvSbJ3+7wU+G/tmCRphViwG6qqPpHku8Cf0C3uV8DNwLuryqmrkrSCDH3Ooqq+CHxxQrFIkmbUSG/KkyStbCYLSVIvk4UkqVfv2lA7JPkF4Ejgpqr60vhC0s4afO7CZy4k7U7D3sF99cD2bwEfBPYG/ri9DlWStEIM64bac2D7JOAfV9UZwCuBN4w1KknSTBnWDfW4JPvRJZRU1b0AVfXDJA9NJDpJ0kwYlix+AriG7h0WleQnq+r/JHkq87/qVJK0TA17gnvdAoceAV47lmi027jIoKTdadjLjzYBV9K9le6KqvoRQFX9P+D2yYSn3cXkIWlXDBvgPgr4HHAM8D+SfCHJ25I8ayKRSZJmxrBuqIeAK9qHJKuBVwF/kuQw4Kqq+p0JxChJmrKRH8qrqq1JzgU+DdwPvHhcQUmSZkvvch9JPpVknyRPAW4BNgP/qqqu7LlUkrRMjNKyOLyq7kvyBuALwCl0U2p9AdIS5oC3pMUYZSHBPZPsCZwIXFRVD443JEnSrBklWXwEuAN4CvDVJM8AfjDOoCRJs2WUZPGXVbWmqo6vqgK+A7x5zHFJkmbIKMniM4M7LWFcMJ5wJEmzaNgT3M8Bngv8RJJfGTi0D/CkcQcmSZodw2ZDPRt4NbAv8MsD5duB3xpjTJKkGTPsCe6LgIuSvLiqrppgTJKkGTPKcxZbkvwBsG7w/KpykFuSVohRksVFwF8BXwYeHm84kqRZNEqyeHJVnTL2SCRJM2uUZPH5JMdX1RfGHo2mxuU/JA0zynMWb6NLGD9Kcl+S7UnuG3dgkqTZ0duyqKq9JxGIJGl2jbJEeZK8Mckftf2Dkxw5wnUHJ/lKkluT3Jzkba18/ySXJbmtfe83cM1pSbYk2Zzk2IHyI5Lc2I59IEl27j9XkrQzRumG+jDdi47+adu/H/jQCNc9RPfei5+he0XryUkOB04FLq+qw4DL2z7t2Aa6p8aPAz6cZI/2W2cDJwGHtc9xI9xfu+D006/8h48kjZIsXlRVJwM/Aqiq/ws8oe+iqtpaVde27e3ArcAa4ATgvHbaeXRLn9PKL6iqB6rqdmALcGR7nes+VXVVW5fq4wPXSJImYJRk8WD7F34BJFkFPLKYmyRZB7wA+AZwUFVthS6hAAe209YAdw5cdlcrW9O255bPd5+TkmxKsunee+9dTIiSpCFGSRYfAD4HHJjkTOBrwL8Z9QZJnkq3cu3bq2rYLKr5xiFqSPljC6vOqar1VbV+1apVo4YoSeoxymyoTya5Bng53V/cJ1bVraP8eHvD3meAT1bVZ1vxPUlWV9XW1sW0rZXfBRw8cPla4O5Wvnaeck2Iz2BIGmU21H8A9q+qD1XVBxeRKAJ8FLi1qt43cOhiYGPb3ki3nMiO8g1JnpjkULqB7KtbV9X2JEe133zTwDWSpAkY5Qnua4F3JXkWXXfUf62qTSNcdzTwG8CNSa5vZX8AnAVcmOQtdG/dex1AVd2c5ELgFrqZVCdX1Y61qN4KnAvsBVzSPpKkCUk3wWiEE5P9gV+lm956SJv6OrPWr19fmzaNktMey+mii2O3lLR8JLmmqtbPLR9lgHuHnwaeQ7dU+bd2U1ySpCVglDGLP01yG/CvgZuAI6rql3sukyQtI6OMWdwOvLiqvjvuYLQ0OVtKWv5G6YY6BzguybsBkhwyytpQkqTlY5Rk8SG6taFe3/a3M9raUJKkZWKUbqgXVdULk1wH3dpQSXrXhpIkLR8TWRtKkrS0jdKymLs21K8B7xprVFrSHPCWlp+xrg0lSVoeRmlZUFXfwgfxJGnFGilZSLtisFvKLilpaVrMch+SpBXKZCFJ6mU3lCbKmVLS0mTLQpLUy2QhSeplspAk9TJZSJJ6mSwkSb2cDaWpcnaUtDSYLDRTTB7SbLIbSpLUy2QhSeplspAk9XLMQjPNMQxpNtiykCT1smWhJcV3Y0jTYbLQkmUXlTQ5dkNJknqZLCRJvUwWkqReJgtJUi8HuLVsOOAtjY8tC0lSL5OFJKnX2JJFko8l2ZbkpoGy/ZNcluS29r3fwLHTkmxJsjnJsQPlRyS5sR37QJKMK2ZJ0vzGOWZxLvBB4OMDZacCl1fVWUlObfunJDkc2AA8F3g68OUkz6qqh4GzgZOArwNfAI4DLhlj3Fom5o5hPPa4YxrSqMaWLKrqq0nWzSk+ATimbZ8HXAGc0sovqKoHgNuTbAGOTHIHsE9VXQWQ5OPAiZgstBu4dIg0uknPhjqoqrYCVNXWJAe28jV0LYcd7mplD7btueXzSnISXSuEQw45ZDeGreXoCj46sGeykIaZlamz841D1JDyeVXVOcA5AOvXr1/wPK1MP54cJC3GpJPFPUlWt1bFamBbK78LOHjgvLXA3a187Tzl0m51zOlv/rH9K07/2JQikWbTpKfOXgxsbNsbgYsGyjckeWKSQ4HDgKtbl9X2JEe1WVBvGrhGkjQhY2tZJDmfbjD7gCR3AX8MnAVcmOQtwHeA1wFU1c1JLgRuAR4CTm4zoQDeSjezai+6gW0HtyVpwsY5G+r1Cxx6+QLnnwmcOU/5JuB5uzE0qZfdUtKP8wluSVKvWZkNJS0ptjy00tiykCT1smUhjWBuS0JaaUwW0m5mF5WWI5OFtBvY8tByZ7KQxsyWhpYDk4WWLdeCknYfZ0NJknrZspAmzG4pLUW2LCRJvWxZSDPGlodmkclCmnGDycPEoWkxWUhT5jMaWgocs5Ak9bJlIS0hfa0Qu6k0LrYsJEm9bFlIy5gzq7S7mCykZaSvm2rYcROJhrEbSpLUy2QhSeplN5QkwJlWGs5koWXDJcnHy8Hylc1kIWmnOFi+spgsJI2drZKlz2Qhabdb7BRek8fsM1lImjpX1p19JgtJM81ZWrPBZCFpSVtMl5bdXzvPZCFppuzq+z12pUvLZLIwk4WkZcsXS+0+JgtJK9ZiZm3NbWUsthWy1AfxTRaSNIJdWdF3sefOYjIxWWjJcnkPaXJMFpI0Y3ZlrGVcrZIls0R5kuOSbE6yJcmp045HklaSJZEskuwBfAh4FXA48Pokh083KklaOZZKN9SRwJaq+l8ASS4ATgBumWpUmjjHKaTpWCrJYg1w58D+XcCL5p6U5CTgpLZ7f5LNO3m/A4Dv7uS142Rci2Nci2NcizOTceWM/7yrcT1jvsKlkiwyT1k9pqDqHOCcXb5Zsqmq1u/q7+xuxrU4xrU4xrU4Ky2uJTFmQdeSOHhgfy1w95RikaQVZ6kki78GDktyaJInABuAi6cckyStGEuiG6qqHkryu8ClwB7Ax6rq5jHecpe7ssbEuBbHuBbHuBZnRcWVqsd0/UuS9GOWSjeUJGmKTBaSpF4miwGztKRIkjuS3Jjk+iSbWtn+SS5Lclv73m9CsXwsybYkNw2ULRhLktNaHW5OcuyE4zo9yd+2ers+yfGTjCvJwUm+kuTWJDcneVsrn2p9DYlr2vX1pCRXJ7mhxXVGK592fS0U11Tra+BeeyS5Lsnn2/7466uq/HTjNnsA3wZ+CngCcANw+BTjuQM4YE7ZvwVObdunAn86oVheArwQuKkvFrrlWG4Anggc2up0jwnGdTrwznnOnUhcwGrghW17b+Bv2r2nWl9D4pp2fQV4atveE/gGcNQM1NdCcU21vgbu9w7gU8Dn2/7Y68uWxaP+YUmRqvp7YMeSIrPkBOC8tn0ecOIkblpVXwX+bsRYTgAuqKoHqup2YAtd3U4qroVMJK6q2lpV17bt7cCtdCsQTLW+hsS1kEnFVVV1f9vds32K6dfXQnEtZGL/3ydZC/wS8J/m3H+s9WWyeNR8S4oM+8M0bgV8Kck1bRkTgIOqait0f/iBA6cW3cKxzEI9/m6Sb7Zuqh3N8YnHlWQd8AK6f5XOTH3NiQumXF+tS+V6YBtwWVXNRH0tEBdM//+v9wO/DzwyUDb2+jJZPGqkJUUm6OiqeiHdSrsnJ3nJFGNZjGnX49nAM4HnA1uBf9fKJxpXkqcCnwHeXlX3DTt1nrJJxjX1+qqqh6vq+XQrMxyZ5HlDTp92XFOtrySvBrZV1TWjXjJP2U7FZbJ41EwtKVJVd7fvbcDn6JqO9yRZDdC+t00rviGxTLUeq+qe9of8EeDPebTJPbG4kuxJ9xfyJ6vqs6146vU1X1yzUF87VNX3gSuA45iB+povrhmor6OB1yS5g66r/GVJPsEE6stk8aiZWVIkyVOS7L1jG3glcFOLZ2M7bSNw0TTiaxaK5WJgQ5InJjkUOAy4elJB7fgD07yWrt4mFleSAB8Fbq2q9w0cmmp9LRTXDNTXqiT7tu29gFcA32L69TVvXNOur6o6rarWVtU6ur+j/ntVvZFJ1Ne4RuuX4gc4nm6WyLeBP5xiHD9FN4PhBuDmHbEATwMuB25r3/tPKJ7z6ZrcD9L9S+Utw2IB/rDV4WbgVROO678ANwLfbH9QVk8yLuAX6Jr53wSub5/jp11fQ+Kadn39LHBdu/9NwLv7/l+fclxTra85MR7Do7Ohxl5fLvchSeplN5QkqZfJQpLUy2QhSeplspAk9TJZSJJ6mSy04iX5n0OO7Zvkdxb5e59rK5JuSfKDgRVKf37OeVe0lUBfM1D2jiTfSrfi8A1J3tceplvoXqcnec+csucnubVtfyXJ/UnWL+a/QZrLZKEVr6p+fsjhfYFFJYuqem11y0T8JvBXVfX89pkvKb2hqi4GSPLP6R7APKqq/hHwc3RP4u415HbnA78+p2wD3YqkVNUvApsWE780H5OFVrwk97fv30vy122RuDPa4bOAZ7aWwXvnXLeutQLOa9d8OsmTdyGUPwTeWt3yElTV31fVWdXWlkryyiRXJbk2yV8keWpVbQa+n+RFA7/zT+iWgpB2G5OFRPcXMd1SCEfSLRJ3RFu88VTg261l8HvzXPps4Jyq+lngPhbZChm4/95070+4fYHjBwDvAl5R3QKTm+jeaQBd62JDO+8o4HtVddvOxCEtxGQhdV7ZPtcB1wLPoUsefe6sqivb9ifoltXYGWFgNdAkx7bWzB1trOMouhfZXNmWzd4IPKOdfgHwa0keR5c0zt/JGKQFPX7aAUgzIsB7quojP1bYvfthmLnr5ezU+jlVdV+SHyY5tKpur6pLgUvTvTbzCS2+y6rq9fNce2dbhfSlwK8CL96ZGKRhbFlInUuBN7f3PZBkTZIDge10ryFdyCFJdvzl/Hrga7sQw3uAswdWOw3wpHbs68DRSX66HXtykmcNXHs+8O/puszu2oUYpHmZLKTuLZpfoptBdFWSG4FPA3tX1ffoun5umjvA3dwKbEzyTWB/upfj7KyzgS8D32i/dyVdt9h1VXUv8M+A89uxr9N1le3wF8BzcWBbY+Kqs1rRkjwNuLaqntF78mOvXUe3RPSwN7sNu/4K4J1VNdaprZO6j5Y3WxZasZI8HbgK+LMphfB3wLmDD+Xtbkm+Qvd+lAfHdQ+tDLYsJEm9bFlIknqZLCRJvUwWkqReJgtJUi+ThSSp1/8HQtzSnMGHp0IAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "## Finally we emulate the trigger selection:\n",
+    "\n",
+    "## trigger function\n",
+    "apply_trigger = lambda x, t: x>t  # is x over threshold\n",
+    "\n",
+    "\n",
+    "threshold = 150. # GeV\n",
+    "\n",
+    "# we check if online jet is above trigger threshold\n",
+    "triggered_events = apply_trigger(online_jets_pt, threshold)  \n",
+    "\n",
+    "# we get the offline jets for events in which the trigger fired\n",
+    "offline_jets_pt_kept = offline_jets_pt[triggered_events]     \n",
+    " \n",
+    "print(\"Minimum offline jet pT: \", offline_jets_pt_kept.min())\n",
+    "print(\"Maximum offline jet pT: \", offline_jets_pt_kept.max())\n",
+    "\n",
+    "\n",
+    "plt.hist(offline_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off)\n",
+    "plt.hist(offline_jets_pt_kept,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off_kept)\n",
+    "\n",
+    "plt.ylabel(f\"events/{bin_width} GeV\")\n",
+    "plt.xlabel(\"jet pT [GeV]\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "5ed95714",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 449
+    },
+    "id": "5ed95714",
+    "outputId": "b1f3c42e-8fae-4b90-e8aa-45723727c509"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAApf0lEQVR4nO3deXhU9d338fc3C/u+KvtSQNEialS0i1RtK1Sli3WtrT62VK32pstdrV3v2qer7W3vVkWqPrTaW9xoqxardWu1SkvQgKCikEUCKiQkLAmQZb7PH+cEJ2EShjCTM5P5vK4r18xZ5pxPcs3kO7+z/H7m7oiISO7KizqAiIhES4VARCTHqRCIiOQ4FQIRkRynQiAikuMKog5wsIYNG+YTJkyIOobIfratWwfAkGnTIk4isr+VK1dWufvwRMuyrhBMmDCB4uLiqGOI7GfJ7NkAXPDMM5HmEEnEzCraW6ZDQyIiOS7rWgQimerkb3876gginaJCIJIi4884I+oIIp2iQ0MiKbKlpIQtJSVRxxA5aGoRiKTIUwsWADpZLNknbS0CM7vTzLaY2Zp2lpuZ/Y+ZrTez1WZ2XLqyiIhI+9J5aGgxcGYHy+cAU8Kf+cCtacwiknNWVtRw89PrWVlRk7J1u9s2u9vvc7DrtrB0dkNtZhOAR9z96ATLbgOecfd7wul1wGx3f6ujbRZN7u/FPzq+9cxp58HMq6CxHpbO3f9FR10KR18K9VXw8Ln7Lz/mSjjifNixER69JMFOvwaTz4Zt6+BvX9x/+axvw/gzYEsJPL1g/+Xv/xGMPgU2PQ/PXb//8g/dBCNmQsUTsPyH+y//8G0wZBpseBiKf7H/8jl3wYCx8Nq9sCpBPT37AegzDNYshrWL91/+yWVQ2AdKboF19+2//PxngscVN0LpI62XFfSGTz0aPH/hBnjzydbLew+Fcx4Mnj/7Tdj8Quvl/cfA3LuD508vCP6G8QZPhY8sCp4/Ph9qXm+9fMTM4O8HsOwzsLOy9fJRJ8MHfhw8f+hTsLu69fJxp8PJ3wmePzgHmna3Xj7pLDjh68Hze2ezn7j33pbvjgojzXx3eQTvPQeqdu2ldGsdP9v1WVbFprNg+hbm7bplv5c/c/j1rG6YwDtr/sJVvZZgZgzr14MeBcF3xCdG/xc1PScxacdTvPftO6ja1YC771vvyQk3sqvH4UytXcYx2+7Zt92GphhVuxq4cvt17LBB/N8pxZyy95H99n/r4F9x36oaLuzxCGf1eq7VvgHun3QXAMdvvYMxNU+12v/A/v1ZNuVOAE565xbG1b3Qat/bYv25Zte3+MSxo/j07ls4vL6k1b63+nDO2/glmmPOd/v9lg8Oqmy175oeE3hizA0AnFJ6PVb7RqvffXu/o3hmVPB5nrPxP+nX+Pa+fbs7Jc1HsmHa9Rw+sDdnV1xDr+baVvt/paCIL5WeRXPMWTzwe4zpT6v9l/afzcrhl/PW9t2cu+GzrfbdoyCP1wfOYdXQiyiI7eYT5fNb/e7uztKGM/Dpn2Ni3z2c/eaXGXflipXuXrT/myjacwSjgY1x05XhvP0KgZnNJ2g1MGNMzy4JJ5Kpdu5pYseeRgb0KqRvzCnfuouKdVuYWF1P3d4m6hqaiMWCL3gONMWcp16roqjf7v22dU/lRl5pKuR9hcG0u7N1516wYPruyjcpbY5xeo+3OKzX3n2va1lv8QvlvBWr42M93mZY77jt+7sPTTFnRXkN43vvv/+l5ZtpoheeYN8Av356PQBf6F3NaYWt9//2jr37ltO7mvweu1vtm3Df96/cxMS+NRxX2Hr/bzXX09Tyd0qw77LmHfz6jWD7h/WtY1J+63Vfqa3l1+uC5ZP67eSw/N2t9h3zYN9mcGT/Ogbntd7/moYd7+4f9tv/P7dU89s163GHTw3cP+cz72zl7j3r6cUeThy4/+8ei8EDKzcxJG87xw3Y/28fL8oWwV+AH7v7c+H0k8A33H1lR9ssKipy3VksmWjT888DMPqUU9K2j5UVNVy4aDmNzTHMoFdhPvUNzQD0KszjqFEDmTFmIAN6FbDw76U0NccoLMjjD5+fxfHjB7e7zYtvX05jU8frJrtetmyzu/0+B1rXzNptEWTfoSEVAslhC5a8xJ9KNu+bPmbMQC46aRwzxgxiyoh+FOS/e2hhZUUNy0urmTVpaLv/OA523e62ze72+3S0bqYWgo8BVwNzgZOA/3H3Ew+0TRUCyVTpbhG8/s5Ozvn1c+xtjpEHB/x2KBKvo0KQtnMEZnYPMBsYZmaVwPeAQgB3XwgsIygC64F64LJ0ZRHpCs9eH5w4TMd9BLX1DXzh98X0713Irz/+Xl7fsjOpb4ciyUhbIXD3Cw+w3IEvpWv/It1FU3OMa+55ibdq93DP/KAF8OGjRkYdS7oR3VkskuF++tfXePaNKn76qfeqBSBpob6GRDLY0hcr+e2zZXzu5PGcf8K4qONIN6VCIJKhVlfWct3Sl5k1aQjfPmt61HGkG9OhIZEUOe2mm1K2rS079zD/9ysZ3q8nN190HIX5+s4m6aNCIJIirbqWOAR7m5q58u4Xqd3dwINXnsLQfrqbXtJLhUAkRSqeeAI4tAFq3J3v/XktKytq+M1Fx3LUqIGpiifSLhUCkRR54YdBh4GHUgjuXl7BkhUbuWr2ZM6aMSpV0UQ6pEIgkgFWVtRwf/FG7i/eyGlHjOBrH5kWdSTJISoEIhFbWVHDRb9dzt6mGAZc9r4J5OfZAV8nkiq6FEEkYstLq2loigFgBqsrt0ecSHKNCoFIxGZNGoqFDYAeBXnMmjQ02kCSc3RoSCRFPnLbbZ163bFjB9GrMJ/3jOjH984+St1ISJdTIRBJkSHTOneCt7y6jvqGZi4+aZyKgERCh4ZEUmTDww+z4eGHD/p1qyprAZgxZlBqA4kkSS0CkRRZ8YtfADD57LMP6nWrNm6nd2E+U0b0S0cskQNSi0AkYqsqazl69IBWw0yKdCW980Qi1NgcY+3mHRyjw0ISIRUCkQite3snDU0xjhk7KOooksNUCEQiVLKxFkAtAomUThaLpMjcu+466NesrqxlcJ9Cxg7pnYZEIslRIRBJkQFjxx70a1Zt3M4xYwdhpr6FJDo6NCSSIq/dey+v3Xtv0uvX7W3ijS07df+ARE4tApEUKbn1VgCOOP/8pNZfs2k7MYeZYzX4jERLLQKRiLT0MqoWgURNhUAkIiWVtYwe1JthGpNYIqZCIBKRVRtrman7ByQDqBCIRKB6114qa3YzY4zOD0j0dLJYJEXOeeCBpNdtOT+gO4olE6gQiKRIn2HDkl53VWUtZnD0aLUIJHo6NCSSImsWL2bN4sVJrbtqYy1TRvSjX099F5PoqRCIpEiyhcDdWVW5Xf0LScZIayEwszPNbJ2ZrTez6xIsH2hmD5vZKjNba2aXpTOPSCaorNnNtroGZuj8gGSItBUCM8sHbgbmANOBC81sepvVvgS84u7HALOBX5hZj3RlEskELUNTzlSLQDJEOlsEJwLr3b3U3RuAJcC8Nus40N+CHrf6AduApjRmEonc6srt9MjPY9ph/aOOIgKktxCMBjbGTVeG8+L9BjgS2Ay8DPyHu8fabsjM5ptZsZkVb926NV15RbpEycZapo8aQI8CnaKTzJDOSxYS9avrbaY/CpQApwGTgb+Z2bPuvqPVi9wXAYsAioqK2m5DJCN8atmyA67THHPWbNrOeUUH32W1SLqk8ytJJRD/bh9D8M0/3mXAUg+sB8qAI9KYSSRtCvv0obBPnw7XWb9lF/UNzbqjWDJKOgvBCmCKmU0MTwBfADzUZp03gdMBzGwkMA0oTWMmkbR56ZZbeOmWWzpcZ1XL0JS6YkgySNoODbl7k5ldDTwG5AN3uvtaM7siXL4QuAFYbGYvExxKutbdq9KVSSSd1t13HwDHXnVVu+usqqylf68CJg7t21WxRA4orbc1uvsyYFmbeQvjnm8GPpLODCKZZFVlLTPGDCQvT0NTSubQZQsiXWRPYzOvvbVTdxRLxlEhEOkir7y1g6aYa0QyyTgqBCJdpOVEsQajkUyjrg9FUuSCZ57pcPnqyu2MHNCTwwb26ppAIklSi0Cki6zaWKvDQpKRVAhEUmTFjTey4sYbEy7bvruR0qo6HRaSjKRCIJIiGx55hA2PPJJw2cvh0JS6o1gykQqBSBdo6Xp6xuhBkeYQSUSFQKQLrNpYy6RhfRnYpzDqKCL7USEQ6QItdxSLZCJdPiqSIgW9eyec//b2PbyzY686mpOMpUIgkiLnPvpowvn7zg/o0lHJUAc8NGRmD5rZx8xMh5FEOmHVxloK8oyjRg2IOopIQsn8c78VuAh4w8x+YmYaOEYkgRduuIEXbrhhv/mrK7dzxOH96VWYH0EqkQM7YCFw9yfc/WLgOKCcYDjJ583sMjPTJRAioYonn6TiySdbzYvFPDxRPCiaUCJJSOpwj5kNBS4FPg+8BPyKoDD8LW3JRLqB8uo6du5pYqYKgWSwA54sNrOlBOMI3wWc7e5vhYvuNbPidIYTyXYtJ4p1xZBksmSuGvqNuz+VaIG7F6U4j0i38rdX3qEw39ixpzHqKCLtSubQ0JFmNqhlwswGm1n7g7KK5KjeQ4fSe+jQfdMrK2p4dM3bNDY7l9zxL1ZW1ESYTqR9yRSCL7h7bcuEu9cAX0hbIpEsNe/BB5n34IP7pl/YUIV78LyxKcby0uqIkol0LJlCkGdm+0baNrN8oEf6Iol0D1NH9gfAgMKCPGZNGtrxC0Qiksw5gseA+8xsIeDAFcBf05pKJAv945vfBOCDP/4xAP16Bh+vTxeN4fwTxnH8+MGRZRPpSDKF4Frgi8CVBF9uHgduT2cokWy0+YUXWk2XVdcBsOCMqYwalLgfIpFMcMBC4O4xgruLb01/HJHuo2xrHT0L8jhsgMYolsyWzH0E7wO+D4wP1zfA3X1SeqOJZLfy6jomDutLXp4deGWRCCVzaOgO4CvASqA5vXFEuo+yqjqmjOgfdQyRA0qmEGx398T964rIPv3HjNn3vKk5xpvb6vnw9MMiTCSSnGQKwdNm9nNgKbC3Zaa7v5i2VCJZ6GN3373v+ebaPTQ2O5OG9Y0wkUhykikEJ4WP8d1JOHBa6uOIdA+lVbsAmKBCIFkgmauGPtQVQUSy3VMLFgBw2k03UV4VXDo6UYVAskAyI5SNNLM7zOzRcHq6mV2ezMbN7EwzW2dm683sunbWmW1mJWa21sz+fnDxRTLHlpIStpSUAFBeXU+/ngUM66eb8CXzJdPFxGKCu4tHhdOvAwsO9KKwK4qbgTnAdOBCM5veZp1BwC3AOe5+FPDpJHOLZLTSquDS0bjeWUQyVjKFYJi73wfEANy9ieQuIz0RWO/upe7eACwB5rVZ5yJgqbu/GW57S9LJRTJYeVWdzg9I1kimENSFI5Q5gJnNArYn8brRwMa46cpwXrypwGAze8bMVprZZxNtyMzmm1mxmRVv3bo1iV2LRKehKUZlTT0Th/aJOopIUpK5auirwEPAZDP7JzAcODeJ1yVqE3uC/R8PnA70Bl4ws+Xu/nqrF7kvAhYBFBUVtd2GSEYYMnUqAG9uqyfmMHG4WgSSHZK5auhFMzsVmEbwz32duycz3FIlMDZuegywOcE6Ve5eR9Dy+AdwDMF5CJGs8pFFi4BgVDKACUNVCCQ7tHtoyMxOCx8/CZxDUAimAmeH8w5kBTDFzCaaWQ/gAoKWRbw/Ax8wswIz60Nwz8KrB/9riGQOXToq2aajFsGpwFPA2QmWOcGdxu1y9yYzu5rgiqN84E53X2tmV4TLF7r7q2b2V2A1wcno2919TSd+D5HIPT5/PgBlc65hcJ9CBvXRpaOSHdotBO7+vfDxss5u3N2XAcvazFvYZvrnwM87uw+RTLHt9eCIZllRnVoDklWSuaHsRwkGr/9hWlOJZLHyal06KtklmctH5yQYvH5u2hKJZLGYO29t38NEnSiWLJJMIcg3s54tE2bWG+jZwfoiOWtPYwzQpaOSXZK5j+Bu4Ekz+38EJ4n/D/C7tKYSyUIjZs7cd8WQLh2VbJLMfQQ/M7OXCW76MuAGd38s7clEssxpN93EzU+vh8fW6WSxZJVkWgSEI5RplDKRAyivqmNE/5707ZnUR0skI3R0Q9lz4eNOM9sR97PTzHZ0XUSR7PCXz3yGvJ9/Q60ByTodfW35LIC7a/RtkSTsrKzEt9aoEEjW6eiqofsBzOzJLsoiktWaY05jc0z3EEjW6ahFkGdm3wOmmtlX2y5091+mL5ZI9tnTGAzToRaBZJuOWgQXAHsIikX/BD8iEkeFQLJVRy2CM939p2bW091/0GWJRLLUnikzeLtwG+OGaEAayS4dtQhaOpv7eBfkEMl6G+ddwZvzrqRXYX7UUUQOSkctglfNrBwYbmar4+Yb4O4+I63JRLJMWVUdk9S1hGShjrqhvtDMDiMYT+Ccroskkn3cnXG3XMeogb3h8r9FHUfkoHR4+6O7vw0cE3Y0N87d13VNLJHssq2ugYJd2+ndsynqKCIHLZnxCM4GSoC/htMzzaztkJMiOa28OuhsTucHJBsl0w3194ETgVoAdy8BJqQrkEg2Kt3aUgiS+UiJZJZk3rVN7r497UlEslh5dR1mRs8CtQgk+yTTReIaM7uIYICaKcCXgefTG0sku5RX1dNwRBET3j8x6igiBy2ZFsE1wFHAXuB/ge3AgjRmEsk6pVV1NF94JSd/5ztRRxE5aMkMTFMPfCv8EZE23J3yqjpOnjQ06iginaIzWyKH6J0de9nd2MygH13FA3PmRB1H5KBpGCWRQ1QWjlPcM9ZI0+6Iw4h0QoctAjPLN7OvdFUYkWykewgk23VYCNy9GZjXRVlEslJZVR09CvLoWaAjrZKdkjk09E8z+w1wL1DXMtPdX0xbKpEsUlZVx4Sh6npaslcyheCU8DF+TAIHTkt9HJHsU1ZVx+ThfZl81llRRxHplGQuH/1QVwQRyUbNMefN6npOP3IEJ1zy9ajjiHRKMp3OjTSzO8zs0XB6upldnv5oIplvc+1uGppjTByqcQgkeyVzdmsxwZgEo8Lp19GdxSLAu5eOThzWlyWzZ7Nk9uxoA4l0QjKFYJi73wfEANy9CWhOZuNmdqaZrTOz9WZ2XQfrnWBmzWZ2blKpRTJEy6WjGrBeslkyhaDOzIYSnCDGzGYR9DfUITPLB24G5gDTgQvNbHo76/2UoNUhklVKt9bRt0c+w/v3jDqKSKclc9XQV4GHgMlm9k9gOJDMN/cTgfXuXgpgZksI7kl4pc161wAPAickG1okU5RX1zFhWF/MLOooIp2WzFVDL5rZqcA0goHr17l7YxLbHg1sjJuuBE6KX8HMRgOfILgUtd1CYGbzgfkA48aNS2LXIl2jrKqO944eGHUMkUNywEJgZp9sM2uqmW0HXnb3LR29NME8bzN9E3Ctuzd39I3K3RcBiwCKiorabkMkEg1NMSprdnPOMcF1FNPOOy/iRCKdk8yhocuBk4Gnw+nZwHKCgvADd7+rnddVAmPjpscAm9usUwQsCYvAMGCumTW5+5+SSi8SoY019TTHnAnhpaPHXnVVxIlEOieZQhADjnT3dyC4rwC4leAwzz+A9grBCmCKmU0ENgEXABfFr+Du+4ZzMrPFwCMqApItylsuHR0eFILG+noACvuouwnJLskUggktRSC0BZjq7tvMrN1zBe7eZGZXE1wNlA/c6e5rzeyKcPnCQwkuErV99xCELYIH584F4IJnnokqkkinJFMInjWzR4D7w+lPAf8ws75AbUcvdPdlwLI28xIWAHe/NIksIhmjrKqOQX0KGdy3R9RRRA5JMoXgSwT//N9HcAL498CD7u6A+iGSnFVeXbfv/IBINkvm8lEHHgh/RCRUtrWOWRqnWLqBZC4f3cn+l31uB4qBr7XcMCaSS/Y0NrN5+x4mqGsJ6QaSOTT0S4LLPv+X4NDQBcBhwDrgToLLSUVySksfQ/GF4OhLL40ojcihSaYQnOnu8XcELzKz5e7+AzO7Pl3BRDJZy6Wjk1QIpBtIptO5mJmdZ2Z54U/87ZO6y1dyUllVcM9AfIugvqqK+qqqqCKJdFoyheBi4BKC+wfeCZ9/xsx6A1enMZtIxiqr2sXw/j3p1/PdRvVD557LQ+eqJ3XJPslcNVQKnN3O4udSG0ckO5RX1WtUMuk22i0EZvYNd/+Zmf2aBIeA3P3LaU0mksFKq+o4/YgRUccQSYmOWgSvho/FXRFEJFvs3NNI1a69unRUuo12C4G7PxyOHna0u/9nF2YSyWh/XfM2AO6xiJOIpEZHh4YKwo7jju/KQCKZbGVFDdf/8WUAfvXkek6aNIzjxw8GYOaVV0YZTaTTOjo09G/gOOAlM3uIoNO5upaF7r40zdlEMs7y0mqamoNTZk3NMZaXVu8rBEecf36U0UQ6LZkbyoYA1QTDSTrB3cUOqBBIzpk1aei+T0BhQV6rvoZ2bAxGZh0wdmw7rxbJTB0VghFm9lVgDe8WgBa6kUxy0rTD+oPDyZOG8PWPHrGvNQCw7JJLAI1HINmno0KQD/QjubGHRXJCyZu1OHDl7Pe0KgIi2ayjQvCWu/+gy5KIZIEV5dvIMzh23KCoo4ikTEddTCRqCYjktOKKbRx5+AD69yqMOopIynRUCE7vshQiWaCxOcaLFbWcMGFI1FFEUqqjG8q2dWUQkUz3yuYd7G5sbrcQnPC1r3VxIpHUSObyUREhOD8AUDQh8UniyWe31zejSGZLphtqEQGKy2sYN6QPIwf0Srh827p1bFu3rotTiRw6tQhEkuDuFFds44NTh7e7zuNf/CKg+wgk+6hFIJKE8up6qnY16ESxdEsqBCJJWFEWnB84oZ3zAyLZTIVAJAkryrcxuE8hk4f3izqKSMqpEIgkobiihqIJQzDTfZbS/ehkscgBbN25l7KqOi48seNeRU/+9re7KJFIaqkQiBzAyoqW+wc6PlE8/owzuiKOSMrp0JDIAawor6FnQR5HjxrY4XpbSkrYUlLSNaFEUiithcDMzjSzdWa23syuS7D8YjNbHf48b2bHpDOPSGcUl29j5thB9Cjo+OPy1IIFPLVgQdeEEkmhtBWCcOD7m4E5wHTgQjOb3ma1MuBUd58B3AAsSlcekc6o29vEms07dP+AdGvpbBGcCKx391J3bwCWAPPiV3D35929JpxcDoxJYx6Rg1aysZbmmHPCRBUC6b7SWQhGAxvjpivDee25HHg00QIzm29mxWZWvHXr1hRGFOlYy0A0x2kgGunG0lkIkh7i0sw+RFAIrk203N0XuXuRuxcNH95+Xy8iqVZcXsMRh2kgGune0nn5aCUQf+H1GGBz25XMbAZwOzDH3avTmEfkoDQ1x3jxzRo+fXxyRyw/8KMfpTmRSHqksxCsAKaY2URgE3ABcFH8CmY2DlgKXOLur6cxi8hBe/WtndQ3NB/w/oEWo085Jc2JRNIjbYXA3ZvM7GrgMSAfuNPd15rZFeHyhcB3gaHALeGt+03uXpSuTCIH498HGIimrU3PPw+oIEj2Seudxe6+DFjWZt7CuOefBz6fzgwinVVcvo0xg3tz+MDeSa3/7PXXAxqPQLKP7iwWScDdWVFew4m6f0BygAqBSAIV1fVU7dqb9PkBkWymQiCSQMtA9RqIRnKBCoFIAsXlNQzSQDSSI9QNtUgCK8q3UTR+MHl5yQ9Ec9pNN6UvkEgaqRCItFG1ay+lVXWcd0LHA9G0NWLmzPQEEkkzHRoSaaO4POgH8WDPD1Q88QQVTzyRjkgiaaUWgUgbxeXbgoFoRnc8EE1bL/zwh4BGKpPsoxaBSBsrKmo4ZuwgehbkRx1FpEuoEIjEqW9oYu2m7bpsVHKKCoFInJKNtTTFXDeSSU5RIRCJs6KsBjM4bpxaBJI7dLJYJE5xxTamjezPwN4HPxDNR267LQ2JRNJPhUAk1NQc48WKGj55XOeGzh4ybVqKE4l0DR0aEgm99vZO6hqaOz1Q/YaHH2bDww+nOJVI+qlFIBJa+mIlAL0KOvf9aMUvfgHA5LPPTlkmka6gFoEIsLKihsXPlwPw5SUvsbKiJtpAIl1IhUAE+MvLm4l58LyxKcby0upoA4l0IRUCyXl7m5p56tUtAOQbFBbkMWvS0IhTiXQdnSOQnHfjY+sor67nm3OOoCnmzJo0lOPH6z4CyR0qBJLTnnujit8+W8Yls8bzxVMnH9K25t51V4pSiXQtFQLJWTV1DXz1vhLeM6If18898pC3N2DswY1fIJIpdI5AcpK7c93S1dTUN/CrC2bSu8eh9zT62r338tq996YgnUjXUotActK9Kzby2Np3+NbcIzlq1MGNO9CekltvBeCI889PyfZEuopaBJJzSrfu4r8efoX3v2cYl79/YtRxRCKnQiA5paEpxn8sKaFnYR6/OO+YgxqcXqS70qEhySn//cTrvLxpOws/czwjB/SKOo5IRlCLQHLGCxuqWfj3DVx44ljOPPqwqOOIZAy1CCQnbK9v5Kv3lTBxaF++c9b0tOzjnAceSMt2RdJNhUC6PXfn+j++zNade1l61Sn06ZGet32fYcPSsl2RdFMhkG5tZUUNtz9byqNr3uYbZ05jxphBadvXmsWLATj60kvTtg+RdEhrITCzM4FfAfnA7e7+kzbLLVw+F6gHLnX3F9OZSbq/7fWNrN+6kydeeYdFz5bRHHPyDE5I84D0KgSSrdJWCMwsH7gZ+DBQCawws4fc/ZW41eYAU8Kfk4Bbw8ekrayoYXlpdVIdhSW7rraZHdt86rV3GDmgF2bG+nd28saWXbyxZRdbd+5N+Jp/l21LezEQyUbpbBGcCKx391IAM1sCzAPiC8E84Pfu7sByMxtkZoe7+1vtbfT1d3by4V/+HYDdjc1sqtmNAwaMHtyb3oWJuwpIdl1tM3O2ObRfD/LzjOYYNMdiNMWc5pjT2ByjsdlbvbZvj3zeM7I/p04dzpQR/Zgysh97G2N85b4SGpti6lpapAPpLASjgY1x05Xs/20/0TqjgVaFwMzmA/MBBoyaxJSR/QBYv2UXLf8OHOjTI5/3jOiXMEyy62qbmbPNkQN6cfSogeTnGwV5Rp4Fj6s31bKirAYH8gzmf3AS1555BMGRxtZGDOiVdGtEJFelsxAkumXTO7EO7r4IWARQVFTkt1x8PBAcHrj49uX7vvH9+JMz2v2wJ7uutpk52/zBvKOT2uaHpx+WsAgAHD9+sAqAyAFYcFQmDRs2Oxn4vrt/NJz+JoC7/zhunduAZ9z9nnB6HTC7o0NDRUVFXlxcvG86m45pa5vRbLOrNNbXA1DYp0/ESUT2Z2Yr3b0o4bI0FoIC4HXgdGATsAK4yN3Xxq3zMeBqgquGTgL+x91P7Gi7bQuBiIgcWEeFIG2Hhty9ycyuBh4juHz0Tndfa2ZXhMsXAssIisB6gstHL0tXHpF0e+mWWwA49qqrIk4icnDSeh+Buy8j+GcfP29h3HMHvpTODCJdZd199wEqBJJ91OmciEiOUyEQEclxKgQiIjlOhUBEJMel7fLRdDGzrUBFijc7DKhK8TbTQTlTSzlTJxsyQm7nHO/uwxMtyLpCkA5mVtze9bWZRDlTSzlTJxsygnK2R4eGRERynAqBiEiOUyEILIo6QJKUM7WUM3WyISMoZ0I6RyAikuPUIhARyXEqBCIiOS7nCoGZfcXM1prZGjO7x8x6mdkQM/ubmb0RPkbSwb2Z3WlmW8xsTdy8drOZ2TfNbL2ZrTOzj0aY8edm9pqZrTazP5rZoCgztpczbtnXzczNbFim5jSza8Isa83sZ5mY08xmmtlyMysxs2IzOzFuWRTvzbFm9rSZvRr+3f4jnJ9pn6H2ckb3OXL3nPkhGAazDOgdTt8HXAr8DLgunHcd8NOI8n0QOA5YEzcvYTZgOrAK6AlMBDYA+RFl/AhQED7/adQZ28sZzh9L0DV6BTAsE3MCHwKeAHqG0yMyNOfjwJzw+VyCQaaifG8eDhwXPu9PMB7K9Az8DLWXM7LPUc61CAi63u4dDpzTB9gMzAN+Fy7/HfDxKIK5+z+AbW1mt5dtHrDE3fe6exnBmA4dDuqTrozu/ri7N4WTy4ExUWZsL2fov4Fv0HpI1EzLeSXwE3ffG66zJUNzOjAgfD6Q4LMUWU53f8vdXwyf7wReJfjyl2mfoYQ5o/wc5VQhcPdNwI3Am8BbwHZ3fxwY6eHwmOHjiOhS7qe9bKOBjXHrVYbzovZ/gEfD5xmV0czOATa5+6o2izIqJzAV+ICZ/cvM/m5mJ4TzMy3nAuDnZraR4HP1zXB+5DnNbAJwLPAvMvgz1CZnvC79HOVUIQiPDc4jaF6NAvqa2WeiTdVpiUZrj/RaYDP7FtAE/KFlVoLVIsloZn2AbwHfTbQ4wbwo/5YFwGBgFvCfwH1mZmReziuBr7j7WOArwB3h/Ehzmlk/4EFggbvv6GjVBPMizxnF5yinCgFwBlDm7lvdvRFYCpwCvGNmhwOEj1s62EZXay9bJcHx7hZjeLdp3uXM7HPAWcDFHh7YJLMyTib4ArDKzMrDLC+a2WFkVk4I8iz1wL+BGEEnZJmW83MEnyGA+3n3cEVkOc2skOCf6x/cvSVbxn2G2skZ2eco1wrBm8AsM+sTfsM6neD43EMEb2rCxz9HlC+R9rI9BFxgZj3NbCIwBfh3BPkwszOBa4Fz3L0+blHGZHT3l919hLtPcPcJBB+u49z97UzKGfoTcBqAmU0FehD0RJlpOTcDp4bPTwPeCJ9HkjP8TN8BvOruv4xblFGfofZyRvo5SvcZ8kz7Af4LeA1YA9xFcCZ+KPAkwRv5SWBIRNnuITh30Ujwj+ryjrIRHOrYAKwjvHojoozrCY5hloQ/C6PM2F7ONsvLCa8ayrScBP/47w7foy8Cp2VozvcDKwmuaPkXcHzE7833ExwyWR33XpybgZ+h9nJG9jlSFxMiIjku1w4NiYhIGyoEIiI5ToVARCTHqRCIiOQ4FQIRkRynQiBZw8y+HPbY+Ifwmuonwp4vzzezZ8ysKFxvWXzPjYewv3PM7LoDrDPbzE45iG2+N8xcYmbbzKwsfP5Em/UmmNluMyuJmzfSzP7XzErNbKWZvWBmnzjA/srMbFqbeTeZ2TfM7ANm9ool6KFVcktB1AFEDsJVBNdQl5nZLKDQ3WcCmNmVLSu5+9xU7MzdHyK4macjs4FdwPNJbvNlYCaAmS0GHnH3B9pZfUPc72cEN5r9zt0vCueNB845wC6XABcQ3D+DmeUB5wLvc/cKM5sLPJJMdum+1CKQjGNmX7VgvIg1ZrYgnLcQmAQ8ZGbXEtxwNTP8Nj25zevLzWxY+K36VTP7bdjv++Nm1jtcZ7KZ/TX8Zv2smR2RIMelZvab8PlwM3vQzFaEP+8LOwy7AvhKmOMDbV7/fTO7y8yesqAv/C8cwp/lNKDB3Re2zHD3Cnf/dbivfAv6s19hQX/2XwxXu4egELT4IFDu7hWHkEW6GbUIJKOY2fHAZcBJBJ1t/cvM/u7uV4S34H/I3avM7F/A1939rPB17W1yCnChu3/BzO4DPkVQRBYBV7j7G2Z2EnALYbcO7fgV8N/u/pyZjQMec/cjwwK1y91vbOd1Mwg6j+sLvGRmf3H3zvQTcxTBXcbtuZygN90TzKwn8E8ze9zdV5tZzMyO8aDX1QsIioPIPioEkmneD/zR3esAzGwp8AHgpU5ur8zdS8LnK4EJFvT6eApwf1wB6XmA7ZwBTI9bf4CZ9U9i/392993AbjN7mqBjtj8lHz8xM7uZ4G/V4O4nEAxqMsPMzg1XGUhQBMsIWwVmtpag991EPbBKDlMhkEzT7lf7Ttob97wZ6E1wSLS25fh7kvKAk8N/6vt00BJp0bYPl8726bKWoDUTbMT9SxYMtVncEgW4xt0fS/DaewhGE/s7sNrfHehGBNA5Ask8/wA+bkEPsX2BTwDPpnIHHvT9XmZmn4bgRKyZHXOAlz0OXN0yYWYzw6c7CYYbbM88C8bFHkpwYnlFJ2M/BfSKPylOMMJei8eAKy3o3hgzmxr+/XD3DUA18BN0WEgSUCGQjOLBEH6LCbrZ/Rdwu7t39rBQRy4GLjezVQTftue1Fyl8/DJQFJ6IfYXgJDHAw8AnEp0sDv0b+AvB0IM3dPL8AB70Dvlx4NTwktB/Ewy7eG24yu3AKwRjLKwBbqN1i/8e4Ajgj53Zv3Rv6n1UpB1m9jVggLt/r5Ov/z4dn0ju6LUTCC4tPboz+860/UhmU4tAJAEzuwK4lOAKoyg0AwPjbyhLtbAF8zDBoDeSw9QiEBHJcWoRiIjkOBUCEZEcp0IgIpLjVAhERHKcCoGISI77/6UpYHuYjuPAAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Now we plot our trigger turn-on: We plot triggered events/total events per bin. \n",
+    "\n",
+    "cnt_total,edges = numpy.histogram(offline_jets_pt, bins=bins, range=[h_min,h_max])\n",
+    "cnt_kept,edges = numpy.histogram(offline_jets_pt_kept, bins=bins, range=[h_min,h_max])\n",
+    "\n",
+    "eff = cnt_kept/cnt_total\n",
+    "centered_pt = (edges+bin_width*0.5)[:-1] # recompute bin edges to plot center of pT bin vs efficiency\n",
+    "\n",
+    "plt.plot(centered_pt, eff, marker=\".\")\n",
+    "\n",
+    "plt.xlim(threshold*0.5-sigma, threshold*1.5+sigma)\n",
+    "plt.axvline(threshold,0,1.0, linestyle='--', color='darkred')\n",
+    "plt.axhline(1.0,0,threshold*1.5+sigma,linestyle='--', color='darkorange')\n",
+    "\n",
+    "\n",
+    "plt.ylabel(f\"Trigger efficiency\")\n",
+    "plt.xlabel(\"offline jet pT [GeV]\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "g1-aGesD67_J",
+   "metadata": {
+    "id": "g1-aGesD67_J"
+   },
+   "source": [
+    "## Measuring jet trigger performance\n",
+    "\n",
+    "You can see that\n",
+    "\n",
+    "(1) The trigger turn-on is not a step function at threshold: There is a gradual turn on of the trigger efficiency, reaching 100% after the trigger threshold.\n",
+    "\n",
+    "(2) We eventually reach 100% trigger efficiency once the offline jet pT is high enough.\n",
+    "\n",
+    "Analysis using hadronic jets typically ensure that they are working in a region where the trigger is almost 100% efficient, by simply selecting events where the leading offline jet pT is greater than the point where the trigger turn-on curve reaches 99%. This means, events collected below the 99% turn-on point are wasted rate. \n",
+    "\n",
+    "One can measure the performance of the trigger by (1) measuring the jet pT @ 99% turn-on and (2) measuring the fraction of events that are wasted. \n",
+    "A good trigger will have a 99% turn-on that is close to threshold, and as little"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "t0Mfb--I6-k8",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "t0Mfb--I6-k8",
+    "outputId": "2eb2b789-3ddc-445a-8e7a-9d3b7c85b5e4"
+   },
+   "outputs": [],
+   "source": [
+    "## Measuring jet trigger performance\n",
+    "\n",
+    "pt_at_99 = centered_pt[eff>=0.99][0]\n",
+    "total_events_triggered = offline_jets_pt_kept.size\n",
+    "total_events_for_physics = offline_jets_pt_kept[offline_jets_pt_kept>=pt_at_99].size\n",
+    "wasted_frac = (total_events_triggered-total_events_for_physics)/total_events_triggered\n",
+    "\n",
+    "print(\"99%% trigger efficiency @ jet pT = %i GeV \"%(pt_at_99))\n",
+    "print(\"Number of triggered events = \", total_events_triggered)\n",
+    "print(\"Number of events for analysis = \", total_events_for_physics)\n",
+    "print(\"fraction of wasted events = %.2f\"%(wasted_frac))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8SPC8LUpCplP",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "8SPC8LUpCplP",
+    "outputId": "f2c8bd14-1cf2-4b3e-e331-bf79a0756f75"
+   },
+   "outputs": [],
+   "source": [
+    "## Measuring jet trigger performance\n",
+    "\n",
+    "pt_at_99 = centered_pt[eff>=0.99][0]\n",
+    "total_events_triggered = offline_jets_pt_kept.size\n",
+    "total_events_for_physics = offline_jets_pt_kept[offline_jets_pt_kept>=pt_at_99].size\n",
+    "wasted_frac = (total_events_triggered-total_events_for_physics)/total_events_triggered\n",
+    "\n",
+    "print(\"99%% trigger efficiency @ jet pT = %i GeV \"%(pt_at_99))\n",
+    "print(\"Number of triggered events = \", total_events_triggered)\n",
+    "print(\"Number of events for analysis = \", total_events_for_physics)\n",
+    "print(\"fraction of wasted events = %.2f\"%(wasted_frac))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43779a38",
+   "metadata": {},
+   "source": [
+    "# Exercise: Measuring the performance of a single lepton trigger \n",
+    "\n",
+    "Next we will do the same thing, but for a single electron trigger and using open data: Specifically a Monte-Carlo sample that contains a decay of a top and an anti-top quark which each decay leptonically (muons or electrons)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f796c028",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%jsroot on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "KlzVoAUWI85c",
+   "metadata": {
+    "id": "KlzVoAUWI85c"
+   },
+   "outputs": [],
+   "source": [
+    "import ROOT\n",
+    "\n",
+    "base_url = \"https://atlas-opendata.web.cern.ch/atlas-opendata/samples/2020/2lep/MC/\"\n",
+    "input_file =  \"mc_410000.ttbar_lep.2lep.root\"\n",
+    "tree_name = \"mini\" # event \"tree\" in which information of each event in the data set are defined:\n",
+    "                   # event level information, particles and their properties\n",
+    "\n",
+    "# function to retrieve the data from an input file.\n",
+    "#events = uproot.open(f\"{base_url}/{input_file}:{tree_name}\")\n",
+    "#events.show()\n",
+    "\n",
+    "infile = ROOT.TFile.Open(f\"{base_url}/{input_file}\")\n",
+    "tree = infile.Get(\"mini\")\n",
+    "tree.GetEntries()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "TToFwf6VOJI2",
+   "metadata": {
+    "id": "TToFwf6VOJI2"
+   },
+   "outputs": [],
+   "source": [
+    "#list_of_variables = ['photon_pt', 'photon_eta', 'photon_phi','scaleFactor_PhotonTRIGGER', 'trigP', 'photon_n', 'photon_trigMatched' ]  # <-- ADD YOUR VARIABLES HERE\n",
+    "#list_of_variables = ['lep_pt', 'lep_eta', 'lep_phi','scaleFactor_LepTRIGGER', 'trigE', 'lep_n', 'lep_trigMatched', 'lep_type', 'trigM' ]  # <-- ADD YOUR VARIABLES HERE\n",
+    "#max_events = 100000\n",
+    "#event_info = events.arrays(list_of_variables, library=\"np\", entry_stop=max_events) \n",
+    "\n",
+    "tree.Print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41389de9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "canvas = ROOT.TCanvas(\"Canvas\", \"c\", 800, 600)\n",
+    "\n",
+    "# --- histogram settings --- \n",
+    "bin_width = 5 # GeV\n",
+    "h_min = 0\n",
+    "h_max = 200\n",
+    "bins = int((h_max-h_min)/bin_width)\n",
+    "\n",
+    "h_total = ROOT.TH1F(\"h_total\",\"offline electron pT spectrum; leading offline electron pT [GeV]; events\",bins,h_min,h_max)\n",
+    "h_triggered = ROOT.TH1F(\"h_triggered\",\"triggered offline electron pT spectrum; leading offline electron pT [GeV]; events\",bins,h_min,h_max)\n",
+    "\n",
+    "h_total.SetLineWidth(2)\n",
+    "h_total.SetLineColor(ROOT.kBlue+2)\n",
+    "h_triggered.SetLineWidth(2)\n",
+    "h_triggered.SetLineColor(ROOT.kOrange+1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23589408",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Loop through all events: Distinguish between \n",
+    "# leading electrons from electron triggered events (trigE == True) \n",
+    "# and leading electrons in all events.\n",
+    "\n",
+    "GeV = 1e-3\n",
+    "\n",
+    "max_events = 200000\n",
+    "\n",
+    "for evt_idx, event in enumerate(tree):\n",
+    "    for l_idx in range(event.lep_n):\n",
+    "        if abs(event.lep_type[l_idx]) == 11:  # 11 is for electron/positron\n",
+    "            electron_pt = event.lep_pt[l_idx]*GeV\n",
+    "            if event.trigE:\n",
+    "                h_triggered.Fill(electron_pt)\n",
+    "            h_total.Fill(electron_pt)\n",
+    "            break # only interested in leading electron\n",
+    "    if evt_idx > max_events: break\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcee80bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h_total.Draw()\n",
+    "h_triggered.Draw(\"SAME\")\n",
+    "canvas.Draw()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b012e62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmax = 100\n",
+    "\n",
+    "## Compute ratio of \"triggered\" vs \"total\" electrons/pT bin\n",
+    "eff = ROOT.TEfficiency(h_triggered, h_total)\n",
+    "eff.SetLineWidth(2)\n",
+    "\n",
+    "\n",
+    "## Draw line to indicate trigger threshold\n",
+    "threshold = 26 # GEV\n",
+    "trig_line = ROOT.TLine(26,0,26,1.0)\n",
+    "trig_line.SetLineColor(ROOT.kRed-2)\n",
+    "trig_line.SetLineWidth(2)\n",
+    "trig_line.SetLineStyle(2)\n",
+    "\n",
+    "## Draw line to indicate 100% trigger efficiency\n",
+    "eff_line = ROOT.TLine(0,1.0,xmax,1.0)\n",
+    "eff_line.SetLineColor(ROOT.kOrange+1)\n",
+    "eff_line.SetLineWidth(2)\n",
+    "eff_line.SetLineStyle(2)\n",
+    "\n",
+    "eff.Draw()\n",
+    "eff_line.Draw()\n",
+    "trig_line.Draw()\n",
+    "canvas.Draw()\n",
+    "\n",
+    "eff.GetPaintedGraph().GetXaxis().SetRangeUser(0,100)\n",
+    "#eff.GetPaintedGraph().GetYaxis().SetRangeUser(0.8,1)\n",
+    "canvas.Draw()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "320b7f76",
+   "metadata": {
+    "id": "FXvtELp2QfmZ"
+   },
+   "source": [
+    " ### What do we observe?\n",
+    " \n",
+    " This matches more or less the officially measured ATLAS trigger efficiency for the 26 GeV single electron trigger:\n",
+    " \n",
+    " <img src=\"https://twiki.cern.ch/twiki/pub/AtlasPublic/EgammaTriggerPublicResults/plot_Et_e24_lhvloose_nod0_L1EM20VH_ProbeLooseAndBLayerLLH_d0z0_DataDriven_Rel21_Smooth_vTest_LooseAndBLayerLLH_d0z0_DataDriven_Rel21_Smooth_vTest_LHCC_Sep2017.png\" width=\"500\" />\n",
+    " \n",
+    " \n",
+    " **Question**: How does this curve look different to the jet trigger turn-ons? Why is it different?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ca4c488",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Session3/Session3_TriggerConcepts.ipynb
+++ b/Session3/Session3_TriggerConcepts.ipynb
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85bab724",
+   "id": "52e3a6ba",
    "metadata": {},
    "source": [
     "# Exercise 1: Emulating a single jet trigger\n",
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "55b0cee5",
    "metadata": {
     "id": "55b0cee5"
@@ -85,7 +85,8 @@
    "outputs": [],
    "source": [
     "import numpy\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.colors as mcolors"
    ]
   },
   {
@@ -102,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "ae0c9ccc",
    "metadata": {
     "colab": {
@@ -112,22 +113,19 @@
     "id": "ae0c9ccc",
     "outputId": "cb911efb-68a5-4f4a-908f-ec28167fc041"
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEGCAYAAACUzrmNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAYqklEQVR4nO3de7BlZXnn8e9PREGFINKQlgZbDUjQSal0ENOWEnUUiRFMNIOXSCoknTFkouWYAMHENhUjGTOMo1FKHC3aUUDiZSCWiMjYZexBSHNRGgFpB0Y69NBIVBqnJFye+WMtZJ/d5+y1T3fvyznn+6natdd691p7PWdVn/P0e1nvm6pCkqRBHjPpACRJ089kIUnqZLKQJHUyWUiSOpksJEmdHjvpAEblgAMOqJUrV046DElaUK655pofVNWy/vJFmyxWrlzJxo0bJx2GJC0oSf7PbOU2Q0mSOpksJEmdTBaSpE4mC0lSJ5OFJKmTyUKS1MlkIUnqZLKQJHUyWUiSOi3aJ7h3xbHHXjjw8/XrTxpTJJI0HaxZSJI6mSwkSZ1MFpKkTiYLSVInk4UkqZPJQpLUyWQhSepkspAkdTJZSJI6mSwkSZ1MFpKkTiYLSVInk4UkqZPJQpLUyWQhSerkehY7oXe9C9e2kLQUmCx2wuG3f7Znz2QhafGzGUqS1MlkIUnqZLKQJHUyWUiSOpksJEmdHA01hJmjnyRp6TFZ7KINa9fO2F/dty9Ji4HNUJKkTtYsdtG68zbN2F+9djJxSNIomSx2M5ulJC1GI2+GSrJHkuuSfLHd3z/J5Ulubd+f3HPsGUk2J7klySt7yo9KckP72QeTZNRxS5IeNY4+i7cBN/Xsnw5cUVWHAVe0+yQ5kmaipWcDxwEfSbJHe845wBrgsPZ13BjiliS1RtoMlWQF8GvAe4F3tMUnAMe22+uA9cBpbfmFVXU/cFuSzcDRSW4H9q2qK9vv/CRwInDpKGPfWfZhSFqMRl2z+ADwp8DDPWUHVdVWgPb9wLb8YOCOnuO2tGUHt9v95TtIsibJxiQb77777t3yA0iSRpgskrwa2FZV1wx7yixlNaB8x8Kqc6tqVVWtWrZs2ZCXlSR1GWUz1GrgNUmOB/YC9k3yKeCuJMuramuS5cC29vgtwCE9568A7mzLV8xSLkkak5Eli6o6AzgDIMmxwDur6s1J3g+cDJzVvl/cnnIJcH6Ss4Gn0nRkX11VDyXZnuQY4CrgLcCHRhX37ta7qh64sp6khWkSz1mcBVyU5BTg+8DrAarqxiQXAd8BHgROraqH2nPeCpwH7E3TsT2VnduStFiNJVlU1XqaUU9U1T3Ay+Y47r00I6f6yzcCzxldhJKkQXyCe8R2nLHWZihJC48TCUqSOpksJEmdTBaSpE4mC0lSJ5OFJKmTyUKS1MlkIUnqZLKQJHUyWUiSOpksJEmdnO5jzDasXTtjf3XfviRNI2sWkqROJgtJUiebocZs3XmbZuyvXjuZOCRpPqxZSJI6WbOYsN5lV11yVdK0smYhSepkspAkdbIZasJmLrtqM5Sk6WTNQpLUyWQhSepkM9QUcSoQSdPKmoUkqZPJQpLUyWQhSepkn8UU6326G3zCW9LkmCxmMfPZB0mSyWKK9M9Iy8ojJhOIJPWZs88iyZ7jDESSNL0GdXD/c5KPJXlpkowtIknS1BmULH4R2Aj8OXBHkg8kecF4wpIkTZM5k0VV3VNVH62qXwWOBm4DPpDke0neO7YIJUkTN1QHd1XdmeTjwA+BdwC/B5w5ysA026gsh85KmoyBD+Ul2SvJ65N8Hvge8DLgDOCp4whOkjQd5qxZJDkfeDnwdeB84I1V9dNhvzjJXu25j2+v89mqeneS/YHPACuB24HfqqoftuecAZwCPAT8cVVd1pYfBZwH7A18CXhbVdV8ftDFwIkGJU3KoGaoy4A/qKrtO/nd9wMvrar72mG430hyKfAbwBVVdVaS04HTgdOSHEnTzvJsmprLV5McXlUPAecAa4Bv0iSL44BLdzKuBav/OYzVaycTh6SlZ1AH97qq2p7koCQfT/JlgCRHJjml64urcV+7u2f7KuAEYF1bvg44sd0+Abiwqu6vqtuAzcDRSZYD+1bVlW1t4pM950iSxmCYiQTPo6llLG/3vwu8fZgvT7JHkuuBbcDlVXUVcFBVbQVo3w9sDz8YuKPn9C1t2cHtdn/5bNdbk2Rjko133333MCFKkoYwTLI4oKouAh4GqKoHafoUOlXVQ1X1XGAFTS3hOQMOn+3BvxpQPtv1zq2qVVW1atmyZcOEKEkawjDJ4idJnkL7BzrJMcCP53ORqvoRsJ6mr+GutmmJ9n1be9gW4JCe01YAd7blK2YplySNyTDJ4h3AJcAzk2yg6TP4D10nJVmWZL92e2+akVU3t991cnvYycDF7fYlwElJHp/k6cBhwNVtU9X2JMe00468peccSdIYdD6UV1XXJnkJ8CyaJqFbquqBIb57ObAuyR40SemiqvpikiuBi9pO8u8Dr2+vc2OSi4DvAA8Cp7YjoQDeyqNDZy9lCY6EkqRJGvScxb40ndG3VtWD7dDWvYHnJ7msqu4a9MVV9W3gebOU30PzcN9s57wX2GEqkaraCAzq75AkjdCgZqi/BVb37L8PWAW8GHjPKIOSJE2XQc1Qvwz8Qc/+9qr6Y4Ak3xhpVJKkqTIoWTy2b0qN3+7Z3m804Wg+XKNb0rgMShYPJ/n5qvq/AFW1CSDJwbTPXGiynJVW0rgM6rN4P/APSV6cZJ/29RLgf7SfSZKWiDlrFlX1qSQ/AP6KZnK/Am4E/qKqHLoqSUvIwOcsqurLwJfHFIskaUoNtVKeFobe9S5c60LS7jTMdB+SpCXOZCFJ6jR0M1SSFwFHA5uq6iujC0k7q3clPVfRk7Q7zVmzSHJ1z/bvA38H7AO8u10OVZK0RAxqhtqzZ3sN8G+r6j3AK4A3jTQqSdJUGdQM9ZgkT6ZJKKmquwGq6idJHhxLdJKkqTAoWfwccA3NGhb1yNQfSZ7E7EudSpIWqUFPcK+c46OHgdeOJBrtNmtWvm7G/rk7zCMlScMbtPjRRmADzap066vqpwBV9f+A28YTnnYXZ6iVtCsGNUMdA7wIOA54T5J7gMuAS6vqu+MITruPM9RK2hWDmqEeBNa3L5IsB14F/FWSw4Arq+oPxxCjJGnChn4or6q2JjkP+CxwH/DCUQUlSZoundN9JDk/yb5Jngh8B7gF+I9VtWHk0UmSpsIwNYsjq+reJG8CvgScRjOk1gWQFjBHS0maj2EmEtwzyZ7AicDFVfXAaEOSJE2bYZLFR4HbgScCX0/yNODHowxKkjRdhkkW/1BVB1fV8VVVwPeB3x1xXJKkKTJMsvhc706bMC6c41hJ0iI06AnuI4BnAz+X5Dd6PtoX2GvUgUmSpseg0VDPAl4N7Af8ek/5duD3RxiTJGnKDHqC+2Lg4iQvrKorxxiTJGnKDPOcxeYkfwas7D2+quzklqQlYphkcTHwj8BXgYdGG44kaRoNkyyeUFWnjTwSSdLUGiZZfDHJ8VX1pZFHo4lx+g9JgwzznMXbaBLGT5Pcm2R7kntHHZgkaXp01iyqap9xBCJJml7DTFGeJG9O8uft/iFJjh7ivEOSfC3JTUluTPK2tnz/JJcnubV9f3LPOWck2ZzkliSv7Ck/KskN7WcfTJKd+3ElSTtjmGaoj9AsdPTGdv8+4MNDnPcgzboXv0izROupSY4ETgeuqKrDgCvafdrPTqJ5avw44CNJ9mi/6xxgDXBY+zpuiOtrF6xZ+bqfvSRpmGTxgqo6FfgpQFX9EHhc10lVtbWqrm23twM3AQcDJwDr2sPW0Ux9Tlt+YVXdX1W3AZuBo9vlXPetqivbeak+2XOOJGkMhhkN9UD7P/wCSLIMeHg+F0myEngecBVwUFVthZ8t1Xpge9jBwDd7TtvSlj3QbveXz3adNTQ1EA499ND5hKgBNqxdO2N/dd++pMVvmJrFB4EvAAcmeS/wDeCvh71AkifRzFz79qoaNIpqtn6IGlC+Y2HVuVW1qqpWLVu2bNgQJUkdhhkN9ekk1wAvo/nDfWJV3TTMl7cr7H0O+HRVfb4tvivJ8rZWsRzY1pZvAQ7pOX0FcGdbvmKWco3JuvM2zdhfvXYycUianM5kkeS/Ap+pqmE6tXvPC/Bx4KaqOrvno0uAk4Gz2veLe8rPT3I28FSajuyrq+qh9tmOY2iasd4CfGg+sWj3sllKWnqG6bO4FnhXksNpmqM+U1UbhzhvNfDbwA1Jrm/L/owmSVyU5BSaVfdeD1BVNya5CPgOzUiqU6vqkbmo3gqcB+wNXNq+JEljkmaA0RAHJvsDv0kzvPXQdujr1Fq1alVt3DhMTtuRw0Xnx6lBpMUjyTVVtaq/fJgO7kf8AnAEzVTlN++muCRJC8AwT3D/TZJbgb8ENgFHVdWvd5wmSVpEhumzuA14YVX9YNTBaGE69tgLZ+yvX3/ShCKRNCrDJItzgTcmeUZV/WWSQ4Gfr6qrRxybFojDd+izMFlIi80wfRYfppkb6g3t/naGmxtKkrRIDFOzeEFVPT/JddDMDZWkc24oSdLiMUzNYpfnhpIkLWzD1Cz654Z6HfCukUalBc0Ob2nxGencUFqa7PCWFp9hahZU1c34IJ4kLVlDJQtpV/ROn+LUINLCNJ/pPiRJS5TJQpLUyWYojVX/jL42S0kLgzULSVInk4UkqZPJQpLUyWQhSepkspAkdXI0lCbK0VHSwmCy0FRxEkJpOpksNFWchFCaTiYLTbUNa9fO2F/dty9pPOzgliR1smahqbbuvE0z9levnUwc0lJnzUKS1MmahRYU18aQJsNkoQXLYbbS+NgMJUnqZM1CC5bPZEjjY7LQouEzGdLo2AwlSepkzUKLhs9kSKNjstCSYTOVtPNshpIkdRpZskjyiSTbkmzqKds/yeVJbm3fn9zz2RlJNie5Jckre8qPSnJD+9kHk2RUMUuSZjfKZqjzgL8DPtlTdjpwRVWdleT0dv+0JEfSjHt8NvBU4KtJDq+qh4BzgDXAN4EvAccBl44wbi0S/Qsr9bNPQxreyJJFVX09ycq+4hOAY9vtdcB64LS2/MKquh+4Lclm4OgktwP7VtWVAEk+CZyIyUK7Qe8T4D79LQ027g7ug6pqK0BVbU1yYFt+ME3N4RFb2rIH2u3+8lklWUNTC+HQQw/djWFrMZr5UJ/JQhpkWjq4Z+uHqAHls6qqc6tqVVWtWrZs2W4LTpKWunHXLO5KsrytVSwHtrXlW4BDeo5bAdzZlq+YpVzarZyUUBps3MniEuBk4Kz2/eKe8vOTnE3TwX0YcHVVPZRke5JjgKuAtwAfGnPMWgL655nasPbmGfs+k6GlbmTJIskFNJ3ZByTZArybJklclOQU4PvA6wGq6sYkFwHfAR4ETm1HQgG8lWZk1d40Hdt2bkvSmKVqzi6ABW3VqlW1cePGnTq3a8illh4XWtJSkeSaqlrVXz4tHdySpCnm3FDSTrBDXEuNNQtJUidrFtIQ+vuxDt/hCGsWWtxMFtJu0Dv9+Znrj5jxmU1UWgxMFtJuMGPhpZVHzH2gtECZLKTdrP8BvzUrZ+47DFcLkR3ckqROJgtJUieboaQx8xkNLUQmC2nMnLRQC5HJQpoy/c902CGuaWCykKacy79qGpgspAmb8YyGNKVMFtKUc61wTQOThbSAdK21Yv+GRsVkIS0iG/pGUjmySruLyUJaxBxZpd3FZCEtIl2d5YOasUwkGsTpPiRJnaxZSJqV/R/qZbKQBHSPtFq9djxxaDqZLCQNpT+ZnPw7z/nZtrWOxc9kIWmn9Hamn7nemXQXO5OFpF3WNZOu65IvfCYLSbtd/xDew5m571KzC4/JQtLE9faHmDimk8lC0lTpH7Lb34TV3+RlchkPk4WkqdafHPrNZ5SWS9ruPJOFpKmyq+t7zDx/7YzPDr+9/7tnJguTydxMFpIWra7E09/k1Z9Mekd1LfVnSUwWkpasrmQyqJbSf25v8xcMbgJbiDUWk4UkDWF+iWXHBxV7+16OPZY5P4Pp7LQ3WUjSCAzqmO/qtO9vHus3iSYxk4UkTZnuWsz41yVZMOtZJDkuyS1JNic5fdLxSNJSsiCSRZI9gA8DrwKOBN6Q5MjJRiVJS8eCSBbA0cDmqvrfVfWvwIXACROOSZKWjIXSZ3EwcEfP/hbgBf0HJVkDrGl370tyy05e7wDgBzt57igZ1/wY1/wY1/xMZVwfS3Y1rqfNVrhQkkVmKasdCqrOBc7d5YslG6tq1a5+z+5mXPNjXPNjXPOz1OJaKM1QW4BDevZXAHdOKBZJWnIWSrL4J+CwJE9P8jiaCV0umXBMkrRkLIhmqKp6MMkfAZcBewCfqKobR3jJXW7KGhHjmh/jmh/jmp8lFVeqdmj6lyRphoXSDCVJmiCThSSpk8mixzRNKZLk9iQ3JLk+yca2bP8klye5tX1/8phi+USSbUk29ZTNGUuSM9p7eEuSV445rrVJ/rm9b9cnOX6ccSU5JMnXktyU5MYkb2vLJ3q/BsQ16fu1V5Krk3yrjes9bfmk79dccU30fvVca48k1yX5Yrs/+vtVVb6afps9gO8BzwAeB3wLOHKC8dwOHNBX9p+A09vt04G/GVMsLwaeD2zqioVmOpZvAY8Hnt7e0z3GGNda4J2zHDuWuIDlwPPb7X2A77bXnuj9GhDXpO9XgCe123sCVwHHTMH9miuuid6vnuu9Azgf+GK7P/L7Zc3iUQthSpETgHXt9jrgxHFctKq+DvzLkLGcAFxYVfdX1W3AZpp7O6645jKWuKpqa1Vd225vB26imYFgovdrQFxzGVdcVVX3tbt7tq9i8vdrrrjmMrZ/90lWAL8G/Le+64/0fpksHjXblCKDfplGrYCvJLmmncYE4KCq2grNLz9w4MSimzuWabiPf5Tk220z1SPV8bHHlWQl8Dya/5VOzf3qiwsmfL/aJpXrgW3A5VU1Ffdrjrhg8v++PgD8KfBwT9nI75fJ4lFDTSkyRqur6vk0M+2emuTFE4xlPiZ9H88Bngk8F9gK/Oe2fKxxJXkS8Dng7VV176BDZykbZ1wTv19V9VBVPZdmZoajkzxnwOGTjmui9yvJq4FtVXXNsKfMUrZTcZksHjVVU4pU1Z3t+zbgCzRVx7uSLAdo37dNKr4BsUz0PlbVXe0v+cPAx3i0yj22uJLsSfMH+dNV9fm2eOL3a7a4puF+PaKqfgSsB45jCu7XbHFNwf1aDbwmye00TeUvTfIpxnC/TBaPmpopRZI8Mck+j2wDrwA2tfGc3B52MnDxJOJrzRXLJcBJSR6f5OnAYcDV4wrqkV+Y1mtp7tvY4koS4OPATVV1ds9HE71fc8U1BfdrWZL92u29gZcDNzP5+zVrXJO+X1V1RlWtqKqVNH+j/mdVvZlx3K9R9dYvxBdwPM0oke8BZ04wjmfQjGD4FnDjI7EATwGuAG5t3/cfUzwX0FS5H6D5n8opg2IBzmzv4S3Aq8Yc138HbgC+3f6iLB9nXMCLaKr53waub1/HT/p+DYhr0vfrl4Dr2utvAv6i69/6hOOa6P3qi/FYHh0NNfL75XQfkqRONkNJkjqZLCRJnUwWkqROJgtJUieThSSpk8lCS16S/zXgs/2S/OE8v+8L7Yykm5P8uGeG0l/pO259OxPoa3rK3pHk5jQzDn8rydntw3RzXWttkvf1lT03yU3t9teS3Jdk1Xx+BqmfyUJLXlX9yoCP9wPmlSyq6rXVTBPxe8A/VtVz29dsSelNVXUJQJJ/T/MA5jFV9W+AX6Z5EnfvAZe7APh3fWUn0cxISlX9KrBxPvFLszFZaMlLcl/7/idJ/qmdJO497cdnAc9sawbv7ztvZVsLWNee89kkT9iFUM4E3lrN9BJU1b9W1VnVzi2V5BVJrkxybZK/T/KkqroF+FGSF/R8z2/RTAUh7TYmC4nmDzHNVAhH00wSd1Q7eePpwPfamsGfzHLqs4Bzq+qXgHuZZy2k5/r70KyfcNscnx8AvAt4eTUTTG6kWdMAmtrFSe1xxwD3VNWtOxOHNBeThdR4Rfu6DrgWOIImeXS5o6o2tNufoplWY2eEntlAk7yyrc3c3vZ1HEOzkM2Gdtrsk4GntYdfCLwuyWNoksYFOxmDNKfHTjoAaUoEeF9VfXRGYbP2wyD98+Xs1Pw5VXVvkp8keXpV3VZVlwGXpVk283FtfJdX1RtmOfeOdhbSlwC/CbxwZ2KQBrFmITUuA363Xe+BJAcnORDYTrMM6VwOTfLIH+c3AN/YhRjeB5zTM9tpgL3az74JrE7yC+1nT0hyeM+5FwD/habJbMsuxCDNymQhNatofoVmBNGVSW4APgvsU1X30DT9bOrv4G7dBJyc5NvA/jSL4+ysc4CvAle137eBplnsuqq6G/gd4IL2s2/SNJU94u+BZ2PHtkbEWWe1pCV5CnBtVT2t8+Adz11JM0X0oJXdBp2/HnhnVY10aOu4rqPFzZqFlqwkTwWuBP52QiH8C3Be70N5u1uSr9Gsj/LAqK6hpcGahSSpkzULSVInk4UkqZPJQpLUyWQhSepkspAkdfr/T5RZH8Q37xsAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# A trigger turn-on emulator for a jet trigger\n",
+    "\n",
+    "def get_subplots(number, width, height):\n",
+    "    fig, ax = plt.subplots(1,number)\n",
+    "    fig.set_size_inches(width,height)\n",
+    "    if isinstance(ax, numpy.ndarray):\n",
+    "        axes = ax\n",
+    "    else:\n",
+    "        axes = numpy.array([ax])\n",
+    "    return fig, axes\n",
+    "\n",
     "\n",
     "## First we generate (our exponentially falling pT) spectrum for the offline reconstructed leading jet\n",
     "\n",
@@ -135,39 +133,53 @@
     "col_on = 'darkred'\n",
     "col_off_kept = 'green'\n",
     "\n",
-    "samples=int(1e5)\n",
+    "samples=int(4e6)\n",
     "\n",
-    "offline_jets_pt = 100*numpy.random.exponential(scale=1, size=samples)\n",
-    "## cut out jets below zero\n",
+    "offline_jets_pt = 10*numpy.random.exponential(scale=10, size=samples)\n",
     "\n",
+    "print(\"minimum jet pT generated = %.5f GeV\"%(offline_jets_pt.min()))\n",
+    "print(\"maximum jet pT generated = %.1f GeV\"%(offline_jets_pt.max()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7e47069",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# --- histogram settings --- \n",
-    "bin_width = 5 # GeV\n",
+    "bin_width = 2 # GeV\n",
     "h_min = 0\n",
-    "h_max = 400\n",
+    "h_max = 600\n",
     "bins = int((h_max-h_min)/bin_width)\n",
     "\n",
-    "plt.hist(offline_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off)\n",
     "\n",
     "## We then generated the pT spectrum of the online reconstructed leading jets\n",
     "## Online reconstruction is not the same as offline due to resolution differences! We'll quantify the \n",
     "## the difference between online and offline jets via a resolution parameter, sigma.\n",
     "\n",
-    "sigma = 5.\n",
-    "gauss = numpy.random.normal(loc=0,scale=sigma, size=samples)\n",
+    "sigmas = [10.,15.,20.,25] ## Add more for comparisons\n",
     "\n",
-    "online_jets_pt = offline_jets_pt + gauss\n",
+    "fig, axes = get_subplots(len(sigmas), 16, 6)                        \n",
     "\n",
-    "plt.hist(offline_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off)\n",
-    "plt.hist(online_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_on)\n",
+    "online_jets_pt_array = []\n",
     "\n",
-    "plt.ylabel(f\"events/{bin_width} GeV\")\n",
-    "plt.xlabel(\"jet pT [GeV]\")\n",
+    "for idx,sigma in enumerate(sigmas):\n",
+    "    gauss = numpy.random.normal(loc=0,scale=sigma, size=samples)\n",
+    "    online_jets_pt = offline_jets_pt + gauss\n",
+    "    online_jets_pt_array.append(online_jets_pt)\n",
+    "    axes[idx].hist(online_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_on, label=f\"online, sigma={sigma} GeV\")\n",
+    "    axes[idx].hist(offline_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off, label=f\"offline\")\n",
+    "    axes[idx].set_ylabel(f\"events/{bin_width} GeV\")\n",
+    "    axes[idx].set_xlabel(\"jet pT [GeV]\")\n",
+    "    axes[idx].legend(loc=\"upper right\")\n",
     "plt.show()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "f5f18138",
    "metadata": {
     "colab": {
@@ -177,51 +189,36 @@
     "id": "f5f18138",
     "outputId": "7bfa260f-d4a4-4b33-a5f9-9154d9d7cdf8"
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtoAAAEGCAYAAABb+jL6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAvMElEQVR4nO3de5hsVXnv++9P8IIXIsjSIJcsYtAEeLyxQogm2bpRQU0AjSR4koCRvYkeNJrERIjnbEncPIFodIuJGKIGcCtIVAJbRUUUjZGLC0RggchSOLKEAMELuHeCQt7zxxwNRa/q7uruqurqru/neeqpWWPOMedbs2aPGj1qzDFSVUiSJEkaroesdACSJEnSWmRFW5IkSRoBK9qSJEnSCFjRliRJkkbAirYkSZI0AtuudACjstNOO9X69etXOgxJWrTLL7/8X6tq3UrHMU6W2ZJWq/nK7DVb0V6/fj0bN25c6TAkadGS/H8rHcO4WWZLWq3mK7PtOiJJkiSNgBVtSZIkaQSsaEuSJEkjYEVbkiRJGgEr2pIkSdIIWNGWJEmSRsCKtiRJkjQCVrQlSZKkEbCiLUmSJI2AFW1pQOuP/cT9D2m1SvL+JLcnuabPujckqSQ79aQdl2RzkuuTHNiTvm+Sq9u6k5OkpT88yYdb+qVJ1o/ljUkaiN9j42VFW5Kmy2nAQbMTk+wGPB/4dk/aXsDhwN4tz7uTbNNWnwIcDezZHjP7PAr4XlX9DPAO4KSRvAtJWgW2XekApNWotzXgphNfvIKRSItTVV+co5X5HcCfAOf2pB0CnFVV9wA3JtkM7JfkJmD7qroYIMkZwKHA+S3P8S3/R4C/TpKqquG/G0lL5ffYeNiiLUlTLsnBwHeq6muzVu0C3NzzektL26Utz05/UJ6quhf4AfC4OY57dJKNSTbecccdy34fkjRpbNGW5jFIP7aZbWwR0GqU5JHAm4AX9FvdJ63mSZ8vz9aJVacCpwJs2LDBFm9Ja44t2pI03Z4E7AF8rXUJ2RW4IslP0rVU79az7a7ALS191z7p9OZJsi3wE8B3Rxi/JE0sW7SlZrn91ezvptWoqq4GHj/zulW2N1TVvyY5D/hQkrcDT6S76fGyqrovyd1J9gcuBY4A3tV2cR5wJHAx8DLgc/bPljStbNGWpCmS5Ey6SvBTkmxJctRc21bVJuBs4FrgU8AxVXVfW/1q4L3AZuCbdDdCArwPeFy7cfIPgWNH8kYkaRWwRVuSpkhVvXyB9etnvT4BOKHPdhuBffqk/ztw2PKilKS1YWQt2kkekeSyJF9LsinJn7X0HZNckOSG9rxDT55FTYwgSZIkTapRtmjfA/znqvphkocCX0pyPvBS4MKqOjHJsXQ/K75x1sQITwQ+m+TJ7WfKmYkRLgE+STcxwvlbH1IajuXOmjVXfvtuS5I0PUbWol2dH7aXD22PopvM4PSWfjrdJAfQMzFCVd1I1+9vvyQ70yZGaDfUnNGTR1pVnPpWkqTpMdKbIZNsk+RK4Hbggqq6FHhCVd0K0J5n7nZfysQIkiRJ0kQaaUW7qu6rqqfTjbG6X5KtbpzpsZSJER68A2cZkyRJ0oQYy/B+VfV94CK6vtW3te4gtOfb22ZLmRhh9nFOraoNVbVh3bp1w3wLkiRJ0qKM7GbIJOuAH1fV95NsBzwPOIkHJjM4sT2f27IsZWIEaVnsLy1JkkZllKOO7AycnmQbupbzs6vq40kuBs5ukyR8mzbealVtSjIzMcK9bD0xwmnAdnSjjTjiiCRJkibayCraVXUV8Iw+6XcCB8yRZ1ETI0iSJEmTypkhNXXsLiJJksZhLDdDSpIkSdPGirYkSZI0Ala0JUmSpBGwj7a0Anr7id904otXMBJJkjQqtmhLkiRJI2BFW5IkSRoBK9qSJEnSCFjRliRJkkbAmyE1NZyoRpIkjZMt2pIkSdIIWNGWpCmS5P1Jbk9yTU/aW5N8PclVSc5J8tiedccl2Zzk+iQH9qTvm+Tqtu7kJGnpD0/y4ZZ+aZL143x/kjRJrGhL0nQ5DThoVtoFwD5V9VTgG8BxAEn2Ag4H9m553p1km5bnFOBoYM/2mNnnUcD3qupngHcAJ43snUjShLOiLUlTpKq+CHx3Vtpnqure9vISYNe2fAhwVlXdU1U3ApuB/ZLsDGxfVRdXVQFnAIf25Dm9LX8EOGCmtVuSpo0VbUlSr1cC57flXYCbe9ZtaWm7tOXZ6Q/K0yrvPwAe1+9ASY5OsjHJxjvuuGNob0CSJoUVbUkSAEneBNwLfHAmqc9mNU/6fHm2Tqw6tao2VNWGdevWLTZcSZp4Du+nNc0h/aTBJDkS+FXggNYdBLqW6t16NtsVuKWl79onvTfPliTbAj/BrK4qkjQtbNGWpCmX5CDgjcDBVfV/eladBxzeRhLZg+6mx8uq6lbg7iT7t/7XRwDn9uQ5si2/DPhcT8VdkqaKLdqSNEWSnAk8B9gpyRbgzXSjjDwcuKDdt3hJVb2qqjYlORu4lq5LyTFVdV/b1avpRjDZjq5P90y/7vcBH0iyma4l+/BxvC9JmkRWtCVpilTVy/skv2+e7U8ATuiTvhHYp0/6vwOHLSdGSVorrGhLK6y3H/lNJ754BSORJEnDZB9tSZIkaQSsaEuSJEkjYEVbkiRJGoGRVbST7Jbk80muS7Ipyeta+vFJvpPkyvZ4UU+e45JsTnJ9kgN70vdNcnVbd7LT+UqSJGnSjfJmyHuBP6qqK5I8Brg8yQVt3Tuq6m29GyfZi24YqL2BJwKfTfLkNpTUKcDRwCXAJ4GDeGAoKUmSJGnijKxFu6puraor2vLdwHXALvNkOQQ4q6ruqaobgc3Afkl2BravqovbpAdnAIeOKm5JkiRpGMYyvF+S9cAzgEuBZwOvSXIEsJGu1ft7dJXwS3qybWlpP27Ls9P7HedoupZvdt999+G+Ca0aq3nadYf6kyRp7Rj5zZBJHg18FHh9Vd1F1w3kScDTgVuBv5rZtE/2mid968SqU6tqQ1VtWLdu3XJDlyRJkpZspC3aSR5KV8n+YFV9DKCqbutZ/3fAx9vLLcBuPdl3BW5p6bv2SZfut5pbsSVJ0to0ylFHQjet73VV9fae9J17NnsJcE1bPg84PMnDk+wB7AlcVlW3Ancn2b/t8wjg3FHFLUmSJA3DKFu0nw38DnB1kitb2p8CL0/ydLruHzcBvwdQVZuSnA1cSzdiyTFtxBGAVwOnAdvRjTbiiCOSJEmaaCOraFfVl+jfv/qT8+Q5ATihT/pGYJ/hRSdJkiSN1lhGHZG0eI5AIknS6uYU7JIkSdIIWNGWJEmSRsCKtiRJkjQCVrQlSZKkEbCiLUmSJI2AFW1JkiRpBKxoS9IUSfL+JLcnuaYnbcckFyS5oT3v0LPuuCSbk1yf5MCe9H2TXN3Wndxm7qXN7vvhln5pkvVjfYOSNEGsaGvVWn/sJ+5/SBrYacBBs9KOBS6sqj2BC9trkuwFHA7s3fK8O8k2Lc8pwNHAnu0xs8+jgO9V1c8A7wBOGtk7kaQJZ0VbkqZIVX0R+O6s5EOA09vy6cChPelnVdU9VXUjsBnYL8nOwPZVdXFVFXDGrDwz+/oIcMBMa7ckTRsr2pKkJ1TVrQDt+fEtfRfg5p7ttrS0Xdry7PQH5amqe4EfAI/rd9AkRyfZmGTjHXfcMaS3IkmTw4q2tArYRUYrpF9LdM2TPl+erROrTq2qDVW1Yd26dUsMUZImlxVtSdJtrTsI7fn2lr4F2K1nu12BW1r6rn3SH5QnybbAT7B1VxVJmgpWtCVJ5wFHtuUjgXN70g9vI4nsQXfT42Wte8ndSfZv/a+PmJVnZl8vAz7X+nFL0tTZdqUDkCSNT5IzgecAOyXZArwZOBE4O8lRwLeBwwCqalOSs4FrgXuBY6rqvrarV9ONYLIdcH57ALwP+ECSzXQt2YeP4W1J0kSyoi1JU6SqXj7HqgPm2P4E4IQ+6RuBffqk/zutoi5J086uI5IkSdIIWNGWJEmSRsCKtiRJkjQCVrQlSZKkEbCiLUmSJI2Ao45Iq0jv7JA3nfjiFYxEkiQtxBZtSZIkaQRGVtFOsluSzye5LsmmJK9r6TsmuSDJDe15h548xyXZnOT6JAf2pO+b5Oq27uQ2E5kkSZI0sUbZon0v8EdV9XPA/sAxSfYCjgUurKo9gQvba9q6w4G9gYOAdyfZpu3rFOBouul/92zrJUmSpIk1sj7aVXUrcGtbvjvJdcAuwCF00/8CnA5cBLyxpZ9VVfcAN7bpe/dLchOwfVVdDJDkDOBQHpjuV5IkSUvk/T+jM3BFu7UuP6E3T1V9e8C864FnAJcCT2iVcKrq1iSPb5vtAlzSk21LS/txW56d3u84R9O1fLP77rsPEpokrWrLKZslSaM1UEU7yWuBNwO3Af/Rkgt46gB5Hw18FHh9Vd01T/fqfitqnvStE6tOBU4F2LBhQ99ttPr1/uctTbPllM2Spoffmytn0Bbt1wFPqao7F7PzJA+lq2R/sKo+1pJvS7Jza83eGbi9pW8BduvJvitwS0vftU+6JE27JZXNkqTxGLSifTPwg8XsuI0M8j7guqp6e8+q84AjgRPb87k96R9K8nbgiXQ3PV5WVfcluTvJ/nRdT44A3rWYWLT6+d+41Neiy2ZJ0vgMWtH+FnBRkk8A98wkzqpAz/Zs4HeAq5Nc2dL+lK6CfXaSo4BvA4e1fW1KcjZwLd2IJcdU1X0t36uB04Dt6G6C9EZISVpa2SxJGpNBK9rfbo+HtceCqupL9O9fDXDAHHlOAE7ok74R2GegSCVpeiy6bJYkjc9AFe2q+rNRByJJWhzLZkmabPNWtJP8j6p6fZL/RZ+RPqrq4JFFJmlejns6vSybJWl1WKhF+wPt+W2jDkSSNDDLZklaBeataFfV5e35C0keBvwsXevJ9VX1ozHEJ0maxbJZklaHhwyyUZIXA98ETgb+Gtic5IWjDEySNL9hl81J/iDJpiTXJDkzySOS7JjkgiQ3tOcderY/LsnmJNcnObAnfd8kV7d1J2eemcokaS0bqKIN/BXw3Kp6TlX9J+C5wDtGF5YkaQBDK5uT7AL8PrChqvYBtgEOB44FLqyqPYEL22uS7NXW7w0cBLy7TQcPcApwNN18CHu29ZI0dQataN9eVZt7Xn+LB2Z0lCStjGGXzdsC2yXZFngk3Sy8hwCnt/WnA4e25UOAs6rqnqq6EdgM7Ndm/N2+qi6uqgLO6MkjSVNloVFHXtoWNyX5JHA2XT/Aw4CvjDg2TTlngxycI5BMl1GUzVX1nSRvoxuX+9+Az1TVZ5I8oapubdvcmuTxLcsuwCU9u9jS0n7clmenS9LUWWjUkV/rWb4N+E9t+Q5gh603lySNwdDL5tb3+hBgD+D7wD8k+e35svRJq3nS+x3zaLouJuy+++6LCVeSVoWFKtoXAJ+uqjvHEYwkaSCjKJufB9xYVXcAJPkY8CzgtiQ7t9bsnXmga8oWYLee/LvSdTXZ0pZnp2+lqk4FTgXYsGFD38q4JK1mC/XR3p2uVeOfkhyf5Be8e1ySVtwoyuZvA/sneWTb1wHAdcB5wJFtmyOBc9vyecDhSR6eZA+6mx4va91M7k6yf9vPET15JGmqLDSO9onAiUkeQ9fa8UrgPUmuAz5F16Jy2+jDlCTNGEXZXFWXJvkIcAVwL/BVutbmRwNnJzmKrjJ+WNt+U5KzgWvb9sdU1X1td68GTgO2A85vD0maOgt1HQGgqu4GzmmPmWGdXkh3N/mB82SVJI3IsMvmqnoz8OZZyffQtW732/4E4IQ+6RuBfRZ7fElaawadsObC3tdVdS3woqqyki1JK8SyWZIm20LD+z2CbizVndod6TN9ALcHnjji2CRJfVg2S9LqsFDXkd8DXk9XcF/OA4X5XcDfjC4sSdI8LJslaRVY6GbIdwLvTPLaqnrXmGLSFHOSGmlhls2StDoMejPku5I8C1jfm6eqzhhRXJKkBVg2S9JkG6iineQDwJOAK4GZ4ZuK7s52SdIKsGyWpMk2UEUb2ADsVVXO3CVJk8OyWZIm2EDD+wHXAD85ykAkDcf6Yz9hX/fpYdksSRNs0BbtnYBrk1xGN3kBAFV18EiikiQNwrJZkibYoBXt40cZhCRpSY5f6QAkSXMbdNSRL4w6EEnS4lg2S9JkG3QK9ruT3NUe/57kviR3LZDn/UluT3JNT9rxSb6T5Mr2eFHPuuOSbE5yfZIDe9L3TXJ1W3dyksw+liRNo6WUzZKk8Rm0Rfsxva+THArst0C204C/Zuthpt5RVW+btb+9gMOBvelmOvtskidX1X3AKcDRwCXAJ4GDgPMHiVuS1rIlls2SpDEZdNSRB6mqfwT+8wLbfBH47oC7PAQ4q6ruqaobgc3Afkl2Bravqovb8FVnAIcuJWZJWusGKZslSeMz6IQ1L+15+RC6sVuXOm7ra5IcAWwE/qiqvgfsQtdiPWNLS/txW56dPlecR9O1frP77rsvMTytBIejkxZvyGWzJGnIBh115Nd6lu8FbqJrhV6sU4C30H0RvAX4K+CVQL9+1zVPel9VdSpwKsCGDRv8spG01g2rbJYkjcCgfbR/dxgHq6rbZpaT/B3w8fZyC7Bbz6a7Are09F37pEvS1BtW2SxJGo1BRx3ZNck5bRSR25J8NMmuC+fcaj8797x8Cd2sZgDnAYcneXiSPYA9gcuq6lbg7iT7t9FGjgDOXexxJWktGlbZLEkajUFvhvx7usrwE+n6SP+vljanJGcCFwNPSbIlyVHAX7ah+q4Cngv8AUBVbQLOBq4FPgUc00YcAXg18F66GyS/iSOOSNKMRZfNkqTxGbSP9rqq6i28T0vy+vkyVNXL+yS/b57tTwBO6JO+EdhnwDglaZosumyWJI3PoC3a/5rkt5Ns0x6/Ddw5ysAkLc/6Yz9x/0Nr1lDL5iSPTfKRJF9Pcl2SX0yyY5ILktzQnnfo2d6JxiRpHoNWtF8J/AbwL8CtwMsAb8KRpJU17LL5ncCnqupngacB1wHHAhdW1Z7Ahe317InGDgLenWSbtp+Zicb2bI+DlhGTJK1ag3YdeQtwZBvzmiQ7Am+jK+SlJbGlVVq2oZXNSbYHfgV4BUBV/Qj4UZJDgOe0zU4HLgLeSM9EY8CNSWYmGruJNtFY2+/MRGPeXyNp6gzaov3UmYIcoKq+CzxjNCFJkgY0zLL5p4E7gL9P8tUk703yKOAJbQQo2vPj2/a7ADf35J+ZUGwXFjHRmCStZYO2aD8kyQ6zWk0GzStphfX+enDTiS9ewUg0ZMMsm7cFngm8tqouTfJOWjeROSx7ojFn85W01g1aIP8V8OUkH6ErMH+DPiOESJLGaphl8xZgS1Vd2l5/hK6ifVuSnavq1jYXwu092y9rojFn85W01g3UdaSqzgB+HbiN7qfFl1bVB0YZmCRpfsMsm6vqX4CbkzylJR1AN7fBecCRLe1IHpg0zInGJGkBA//EWFXX0hW6kqQJMeSy+bXAB5M8DPgW3QgmDwHObpOOfRs4rB13U5KZicbuZeuJxk4DtqO7CdIbISVNJftZS5IAqKorgQ19Vh0wx/ZONCZJ87CiLUmSJMCb54fNirYkSdIa41wVk2HQcbQlSZIkLYIVbUmSJGkE7DqisfKnLEmSNC1s0ZYkSZJGwIq2JEmSNAJ2HZGmjEM3SZI0HrZoS5IkSSNgRVuSJEkaASvakiRJ0ghY0ZYkSZJGwIq2JEmSNAKOOqKRc5KayTXz2Tj6iCRJwzeyFu0k709ye5JretJ2THJBkhva8w49645LsjnJ9UkO7EnfN8nVbd3JSTKqmCVJkqRhGWXXkdOAg2alHQtcWFV7Ahe21yTZCzgc2LvleXeSbVqeU4CjgT3bY/Y+JUmSpIkzsop2VX0R+O6s5EOA09vy6cChPelnVdU9VXUjsBnYL8nOwPZVdXFVFXBGTx5JkiRpYo37ZsgnVNWtAO358S19F+Dmnu22tLRd2vLs9L6SHJ1kY5KNd9xxx1ADlyRJkhZjUkYd6dfvuuZJ76uqTq2qDVW1Yd26dUMLTpIkSVqscVe0b2vdQWjPt7f0LcBuPdvtCtzS0nftky5JkiRNtHFXtM8DjmzLRwLn9qQfnuThSfagu+nxsta95O4k+7fRRo7oyaMJt/7YTzi0nyRJmlqjHN7vTOBi4ClJtiQ5CjgReH6SG4Dnt9dU1SbgbOBa4FPAMVV1X9vVq4H30t0g+U3g/FHFLEnTLsk2Sb6a5OPttcOyStISjWzCmqp6+RyrDphj+xOAE/qkbwT2GWJokqS5vQ64Dti+vZ4ZlvXEJMe212+cNSzrE4HPJnlyaySZGZb1EuCTdMOy2kgiaepMys2QklbQTDcfu/pMtyS7Ai+m+xVxhsOyStISWdGWJM34H8CfAP/RkzayYVkdklXSWmdFW5JEkl8Fbq+qywfN0idtUcOyOiSrpLVuZH20Ja1Ovd1HbjrxxSsYicbs2cDBSV4EPALYPsn/pA3LWlW3OiyrJC2OFW0NlX18pdWpqo4DjgNI8hzgDVX120neSjcc64lsPSzrh5K8ne5myJlhWe9LcneS/YFL6YZlfdc434skTQor2pKk+ZwInN2GaP02cBh0w7ImmRmW9V62Hpb1NGA7utFGHHFEGgMbuyaPFW1J0oNU1UXARW35ThyWVZpKMxV3uxEunTdDSpIkSSNgRVuSJEkaASvakiRJ0gjYR1vL5s0XkiRJW7NFW5IkSRoBK9qSJEnSCNh1RNKcnCVSkqSls0VbkiRJGgEr2pIkSdII2HVES+JII5IkSfOzRVuSJEkaASvakiRJ0gjYdUTSQByBRJKkxbFFW5IkSRoBW7QlSZJWKQcnmGxWtCVJkjQnuw4u3YpUtJPcBNwN3AfcW1UbkuwIfBhYD9wE/EZVfa9tfxxwVNv+96vq0ysQ9tTzv2bNmLkWLHAlSZrbSvbRfm5VPb2qNrTXxwIXVtWewIXtNUn2Ag4H9gYOAt6dZJuVCFiSJEka1CTdDHkIcHpbPh04tCf9rKq6p6puBDYD+40/PEmSJGlwK1XRLuAzSS5PcnRLe0JV3QrQnh/f0ncBbu7Ju6WlbSXJ0Uk2Jtl4xx13jCh0SZIkaWErVdF+dlU9E3ghcEySX5ln2/RJq34bVtWpVbWhqjasW7duGHFK0lRIsluSzye5LsmmJK9r6TsmuSDJDe15h548xyXZnOT6JAf2pO+b5Oq27uQk/cpxSVrzVqSiXVW3tOfbgXPouoLclmRngPZ8e9t8C7BbT/ZdgVvGF60kTYV7gT+qqp8D9qdrBNmLpd0/cwpwNLBnexw0zjciSZNi7KOOJHkU8JCqurstvwD4c+A84EjgxPZ8bstyHvChJG8HnkhXaF827rglbc0hn9aO1mVvpvve3Umuo+umdwjwnLbZ6cBFwBvpuX8GuDHJZmC/NqrU9lV1MUCSM+juuTl/XO9FmgaOBLY6rMTwfk8Azmm/JG4LfKiqPpXkK8DZSY4Cvg0cBlBVm5KcDVxL1+JyTFXdtwJxS9JUSLIeeAZwKbPun0nSe//MJT3ZZu6f+XFbnp3e7zhH07V8s/vuuw/xHUgaFRtYFmfsFe2q+hbwtD7pdwIHzJHnBOCEEYemOfhfszQ9kjwa+Cjw+qq6a57u1XPdP7Oo+2qAUwE2bNjQdxtJWs0maXg/SdIKSvJQukr2B6vqYy15sffPbGnLs9Mlaeo4Bbv6shVbi+XPiatbGxnkfcB1VfX2nlWLun+mqu5LcneS/em6nhwBvGtMb0OSJooVbUkSwLOB3wGuTnJlS/tTugr2Yu+feTVwGrAd3U2Q3ggpaSpZ0ZYkUVVfon//aljk/TNVtRHYZ3jRSdLqZEVbkiRpFbBb5+rjzZCSJEnSCNiirfv5n7KGxRsjJWnts6xfmC3akkZq/bGf8J84SdJUskV7ylkBkiRJGg0r2pLGwp8YJWnxbBBb3ew6IkmSpGWxm2B/VrQlSZKkEbDryJTyv05JkqTRsqItSZI0QVZzY5j34zyYFe0pspr/cCVJklYbK9qSxs4WD0na2lprELOst6ItaYVZEEuS1ior2mvQWvuPWJKktWpavrOntVHFirakiTFTEE9TISxp+kxL5VpWtNcU/3AlSZpMfkc/oN+5WKsNLFa0Vzn/cLUWTetPjJI0rdZquW9FW9JEW6uFr6S1y0aw5VlL5b4V7VXIP2BJklae38ejt9q7mVjRXiX8Y5ZWf4ErafXye3hyDPJZTMp3w6qpaCc5CHgnsA3w3qo6cYVDGhn/mKXBzfX3MimF7LSapjJbq4vfsdNhMZ/zKL8vVkVFO8k2wN8Azwe2AF9Jcl5VXbuykQ2Pf/jScK2lPn6rzTSU2VqeQf4+/V7UuIxyaNlVUdEG9gM2V9W3AJKcBRwCTEShbWEgTbal/o32K3TnqiA4BviDTHSZDYv7vCzjR8vzq7VstVS0dwFu7nm9BfiF2RslORo4ur38YZLrl3CsnYB/XUK+YZuUOGByYpmUOGByYpmUOGANxpKTFr9+VtpS4/ipJeSZJKumzF7oMx5XHENmLFublDhgcmKZlDhgQmLJScMvs1dLRTt90mqrhKpTgVOXdaBkY1VtWM4+hmFS4oDJiWVS4oDJiWVS4gBjmeQ4VoBl9goylsmNAyYnlkmJAyYnllHE8ZBh7myEtgC79bzeFbhlhWKRJM3PMluSWD0V7a8AeybZI8nDgMOB81Y4JklSf5bZksQq6TpSVfcmeQ3wabqhot5fVZtGdLhl/Yw5RJMSB0xOLJMSB0xOLJMSBxhLP5MSx1hZZq84Y9napMQBkxPLpMQBkxPL0ONI1Vbd5iRJkiQt02rpOiJJkiStKla0JUmSpBGwog0keWuSrye5Ksk5SR7bs+64JJuTXJ/kwDHEcliSTUn+I8mGnvT1Sf4tyZXt8Z6ViKOtG+s5mXXs45N8p+c8vGjMxz+ove/NSY4d57H7xHJTkqvbedg45mO/P8ntSa7pSdsxyQVJbmjPO6xQHCtyjSTZLcnnk1zX/nZe19LHfl7WmkHP4Vx/E8P6DAbZz1zXQVu3rGtzofInnZPb+quSPHPQvIs1QCy/1WK4KsmXkzytZ91Qy64BYnlOkh/0nPf/NmjeIcfxxz0xXJPkviQ7tnVDOyf9ysVZ68d5nSwUy1iukwHiGN01UlVT/wBeAGzblk8CTmrLewFfAx4O7AF8E9hmxLH8HPAU4CJgQ0/6euCaMZ6TueIY+zmZFdfxwBtW6DrZpr3fnwYe1s7DXisRS4vnJmCnFTr2rwDP7L0mgb8Ejm3Lx878Ha1AHCtyjQA7A89sy48BvtH+XsZ+XtbaY9BzONffxLA+g0H2M9d10F4v+docpPwBXgScTzeO+f7ApYPmHUEszwJ2aMsvnIllvs9phLE8B/j4UvIOM45Z2/8a8LkRnZOtysWVuE4GjGVc18lCcYzsGrFFG6iqz1TVve3lJXRjvkI3ZfBZVXVPVd0IbKabWniUsVxXVUuZHW1ccYz9nEyQ+6eVrqofATPTSk+dqvoi8N1ZyYcAp7fl04FDVyiOFVFVt1bVFW35buA6uhkSx35e1qDlnsNhfQYL7mee62C5Bil/DgHOqM4lwGOT7Dxg3qHGUlVfrqrvtZe936vDtpz3Nszzsth9vRw4c4nHmtcA5eK4rpMFYxnXdbKM74plnxMr2lt7Jd1/etB/GuFhFJhLtUeSryb5QpJfXqEYJuGcvKb9zPT+pf4EvEST8N57FfCZJJenm8p6pT2hqm6FrrIBPH4FY1mpawTounoBzwAuZbLOy2o16Dmc629iWJ/BovYz6zqYsdRrc5DyZ65thl12LXZ/R/HA9yoMt+waNJZfTPK1JOcn2XuReYcZB0keCRwEfLQneZzl+biuk8Ua5XUyiJFcI6tiHO1hSPJZ4Cf7rHpTVZ3btnkTcC/wwZlsfbZf9niIg8TSx63A7lV1Z5J9gX9MsndV3TXmOEZyTh50gHniAk4B3tKO+Rbgr+j+ORqHkb/3RXp2Vd2S5PHABUm+3v5rn3YreY2Q5NF0X6Cvr6q7kn6XjWZb4O9+UMv+mxhSHFtdBy15OdfmIOXPXNsMu+waeH9JnktXgfqlnuRhll2DxHIF8FNV9cN0/eL/EdhzwLzDjGPGrwH/XFW9LazjLM/HdZ0MbAzXyUJGdo1MTUW7qp433/okRwK/ChxQrWMOI5pGeKFY5shzD3BPW748yTeBJwNLvkFgKXEwhqmVB40ryd8BHx/msRcwUdNKV9Ut7fn2JOfQ/cS1khXt25LsXFW3tp8hb1+JIKrqtpnlcV8jSR5KV7n6YFV9rCVPxHmZdPP93ScZ6BzO8zcx8GcwjDjmuA6We20OUv7Mtc3DBsi7GAOVhUmeCrwXeGFV3TmTPuSya8FYehukquqTSd6dZKdB38ew4uhxOLO6jYy5PB/XdTKQMV0n8xrlNWLXEbo7SoE3AgdX1f/pWXUecHiShyfZg+6/m8tWKMZ1SbZpyz/dYvnWCoSyouekfbnNeAnQ9w7iEZmYaaWTPCrJY2aW6W7oHee56Oc84Mi2fCQw168iI7VS10i6puv3AddV1dt7Vk3EeVnlFjyHC/xNDOszGCSOua6D5V6bg5Q/5wFHpLM/8IPWxWXYZdeC+0uyO/Ax4Heq6hs96cMuuwaJ5Sfb50KS/ejqPncOkneYcbTj/wTwn+i5dlagPB/XdbKgMV4nC8UxumukhnA352p/0N3QdzNwZXu8p2fdm+juOL2e7r+tUcfyErr/oO4BbgM+3dJ/HdhEd8frFcCvrUQcK3FOZsX1AeBq4Kp2se885uO/iG4UgW/SdbFZqWv2p9u18LV2XYw1FrrWmFuBH7fr5CjgccCFwA3teccVimNFrhG6nzyrHXemLHnRSpyXtfaY6xwCTwQ+2Zbn/JsY1mcwYBx9r4O2blnXZr/yB3gV8Kq2HOBv2vqrefCIUUMtuwaI5b3A93rOwcaFPqcRxvIaHvj+vAR41ijOy0JxtNevoBtQoDffUM8J/cvFlbpOFoplLNfJAHGM7BpxCnZJkiRpBOw6IkmSJI2AFW1JkiRpBKxoS5IkSSNgRVuSJEkaASvakiRJ0ghY0da8kpyW5GVt+b1J9hrCPjckOXmBbZ7eZmcadJ+PS3Jle/xLku/0vH7YEGJ+a5JN7XldkkuTfDXJLye5qQ1sT5IvL/dYbT+vSnLEAtscupjPI8mBPefkh0mub8tnzNruOUl+kOSTPWl7Jvl4km+mmw7380l+ZZ5jPSrJnW3M2N70f0zyG0l+M8nmJOOccEiaKmup/E7yt0mePc8+frZt/9UkT0ry+0muS/LBJK9I8tdtuwXL1kXEPW95n+SxSf7vRe7znPY+NrdyeOY8PGvWdhe1MvzgnrQ/TPL1JFenm0r87ekmT5rrWMcn+YtZaU9Pcl1b/nz7rtiwmPegWZY7RqKPtf0ATgNetgLHfQXw10vMezzwhiHHcxfw8LZ8OHB6z7qbgJ1W02cDXETP2Kmz1j0H+HjP60fQjSF6cE/aPsArFjjGmcCRPa9/AvhX4JH9juPDh4/hPtZS+U03xvI28+Q7FvizntdfB/ZYbjzLPA/rgWuWmHfe8nF2GU43JvSngMe21w9r52T7efbxFOBbs9JOBP7fuY7jY/EPW7SnTPuP95r2eH1LW9/+8/+71mr7mSTb9cl70cx/tu2/3BPaf82XJHlCS1+X5KNJvtIeW7VAtBbTj7flRyV5f9v2q0kOaS0Yfw78ZvtP/jdn5X9FknOTfKr9R//mIZ2bpGuxvqa1CPxmSz8PeBRwaZI3An8JvKjFtt2sffyw5z1elOQjrYXhg8n9s07tm+QL6VqGP50HzxY3s5/jk7yhLT+pvdfLk/xTa7l5FnAw8NYWx5Nm5T8tyXva9t9I8qvLODW/BVxcVffPhlVV11TVae1YW32GbbMz6f4pmfES4FP14NlXJQ1oWsvvJD8HfKOq7kvX4npJkqvStf7ukK71/PXAf0nXCvseuglPzkvyB7P21Vu2XpTkpCSXtXLyl1v6Nu274CvtOL83R1w/7Fn+457t/6wlnwg8qZ2Ht87Ku759N5ze8nwkySMXOhfzeBPw6qr6PkBV/aiqTqw2tXiSFyS5OMkVSf4hyaOr6nrg+0l+oWc/vwGctYw4NIsV7SmSZF/gd4FfAPYH/muSZ7TVewJ/U1V7A9+nm4lyPo8CLqmqpwFfBP5rS38n8I6q+vm2j/cusJ83AZ9r2z8XeCvwUOC/AR+uqqdX1Yf75NuPrgL4dOCwDOenrZe2/T0NeB5dJXbnqjoY+LcWy0mzYvu3efb3DLrCfy+6Qv/Z6X7GexddK9O+wPuBExaI61TgtW37NwDvrqov080s98ctjm/2ybeebqrfFwPvSfKIBc9Af3vTzUY6l60+w3RT5n4K2DfJ49p2h9NVviUt0pSX3y+kK08AzgDeWFVPpZvV8M1V9UngPS3251bVq4BbgOdW1TsW2Pe2VbUfXVk9U+k/im5a8p8Hfp7uXO8x1w6SvIDuM9ivvad903WtOxb4ZjsPf9wn61OAU9t7uQtYVDeTnuM/Bnh0Vd04x/qdgP8HeF5VPRPYCPxhW31/g0i66djvrKoblhKH+tt2pQPQWP0ScE5V/W+AJB8DfpmuwnZjVV3ZtrucrpI2nx8BM/1rLwee35afB+zVGm8Btk/ymKq6e479vAA4eKaFga6bwu4DvJcLqurOnvfxS3SFx3L8EnBmVd0H3JbkC3SF7HnzZ5vTZVW1pcV4Jd05/T5dt4sL2jnahm5a2L6SPBp4FvAPPef04QMe/+yq+g/ghiTfAn6W7ufXZUlyDt2Xyjeq6qXM8RlW1XXpfg14WZKP0n0BfWa5x5em1DSX3wcCv5vuno/HVtUXWvrpwD8McLz5fKw99563FwBPTevfTtftbU+gb0W2bf8C4Kvt9aPb9t9e4Ng3V9U/t+X/Cfw+8LbFBN8EuH+a7yQHAicBjwX+L2BHugaff26f7cOAi9vmZwFfTvJH2BgyEla0p0vmWXdPz/J9wFY/Pc7y46qa+cO+jweupYcAv7hAS+/smH69/YT1QOKDf8rqpxZ43f9gyUt4oNXiv1RVb+E+3/lZitnndNt2jE1V9YsD7uMhwPer6ulLOP6SzlEfm4D7b3ysqpe0FqiZL4S+n2FzJl1LSoBzq+rHS4xBmnZTWX637hSPrapbMuvm6iGZOXe95yF0vyJ+esB9BPiLqvrbByUm6xfIN5QyuqruSvK/k+xRVTe2uD/duvg8rMV3QVW9vE/em5PcRPfr568Dg343aUB2HZkuXwQOTfLI9tP+S4B/GvIxPgO8ZuZFkqcvsP2ngdcm9/dfnvkp9G7gMfPke36SHdP1RTwU+Od5tr1fVZ3TfsZ7+qxKNnTn5zdb/7x1dJXLywbZ7yJcD6xL8osASR6aZO954r0LuDHJYW37JHlaW73QOTosyUPS9d/+6XbspfgQXbeXg3vSevsSzvUZAnyermXnGGwpkZZjWsvv59KVI1TVD4DvzfSlBn4H+MJcGZfh08CrW1c/kjy5nfP5tn9l+wWSJLskeTwLn4fdZ74LgJcDX1pGzH8BnJLksS2G0P3CAHAJXRn+M23dI5M8uSfvmcA76Lq5bFlGDOrDivYUqaor6O5Cvwy4FHhvVX113kyL9/vAhnZzx7V0d0L3Dac9v4WuT99VSa5pr6ErWPdKn5tpmi8BH6DrCvHRPpXmpTgHuAr4GvA54E+q6l+GsN/7VdWPgJcBJyX5Gl38z5pr8/b8W8BRbftNwMzNhmcBf5w2nFWf/NfTfQmdD7yqqv59iTH/G/CrwKuSfCvJxXSt1P+9bTLXZ0jruvJR4HF0FQVJSzDF5Xdv/2yAI+nuA7mKrjvany/4rhbvvcC1wBXtff0t/XsAFEBVfYauQeLiJFcDHwEe07rH/HO6m1ff2if/dcCR7b3sCJyyjJhPAT5Ld9P+VXT/vHwV+GpV3UE38sqZbd0ldF0JZ/wD3b043gQ5Anng1yNpPJL8Ot1QcUcuMf8r6IYbes1C265WSd4FXFFVf7/E/KfRDQ31kSXkfQ7d8FrLGalkYo4jaXjGXX4nuQL4hUnrdpbuJu8rquqnlph/PV0Zvc8S819EV34Oo5FpxY+zltmirbFq3Q9OoGshUB9J3kI3ssBSb8Jcrh8B+6Rnwppha61c7wa+N6pjSBqulSi/q+qZE1jJfiLdzYRLuXFxWL4LnDarS99QJfk8XbfDiTr/q40t2pIkSdII2KItSZIkjYAVbUmSJGkErGhLkiRJI2BFW5IkSRoBK9qSJEnSCPz/1v0C12GeZzsAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 864x288 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "standard deviation of distribution = 5.0 GeV\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "## Now we plot the online vs offline response.\n",
     "## This should have a spread determined by our sigma set above.\n",
-    "\n",
-    "fig, (ax1, ax2) = plt.subplots(1, 2)\n",
+    "fig, (ax1,ax2) = plt.subplots(1, 2)\n",
     "fig.set_size_inches(12,4)\n",
     "\n",
-    "pt_ratio = online_jets_pt/offline_jets_pt\n",
-    "pt_diff = online_jets_pt-offline_jets_pt\n",
+    "colours= mcolors.TABLEAU_COLORS#[\"red\", \"blue\", \"green\", \"orange\"]\n",
     "\n",
-    "ax1.hist(pt_diff, bins=100, range=[-20,20])\n",
-    "ax1.set_ylabel(f\"count/bin\")\n",
-    "ax1.set_xlabel(\"online jet pT - offline jet pT [GeV]\")\n",
-    "ax2.hist(pt_ratio, bins=100, range=[-0.5,1.5])\n",
+    "for idx, online_jets_pt in enumerate(online_jets_pt_array):\n",
+    "    sigma = sigmas[idx]\n",
+    "    pt_ratio = online_jets_pt/offline_jets_pt\n",
+    "    pt_diff = online_jets_pt-offline_jets_pt\n",
+    "    ax1.hist(pt_diff, bins=100, range=[-50,50], alpha=0.2, label=f\"$\\sigma$={sigma}\")\n",
+    "    ax2.hist(pt_ratio, bins=100, range=[-0.5,2.5], alpha=0.4, label=f\"$\\sigma$={sigma}\")\n",
+    "    ax1.set_ylabel(f\"count/bin\")\n",
+    "    print(\"standard deviation of distribution = %.1f GeV\"%(pt_diff.std()))\n",
+    "\n",
+    "ax1.set_xlabel(\"online jet pT - offline jet pT [GeV]\") \n",
     "ax2.set_ylabel(f\"count/bin\")\n",
     "ax2.set_xlabel(\"online jet pT/offline jet pT [GeV]\")\n",
+    "ax1.legend(loc=\"upper right\")\n",
+    "ax2.legend(loc=\"upper right\")\n",
     "plt.show()\n",
-    "\n",
-    "print(\"standard deviation of distribution = %.1f GeV\"%(pt_diff.std()))"
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "40027bcd",
    "metadata": {
     "colab": {
@@ -231,58 +228,39 @@
     "id": "40027bcd",
     "outputId": "896e320f-9325-4081-83d5-d84a347dec5e"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Minimum offline jet pT:  133.1700364964153\n",
-      "Maximum offline jet pT:  1492.4783182402612\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEGCAYAAACUzrmNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAXOUlEQVR4nO3dfbRldX3f8fdHREWFADKQcQYcYlCDNktlghiylKgVJEYwic1YjdOlCakhrS5rAiTGQFeopKbWWpUlqRasCiU+FOISEanUSFEyPMmTE8ZChTBl0FQZ7JLw8O0f+zfheLn37HNn5jzce9+vtc46e//23md/+S1mvvN72L+dqkKSpGEeN+0AJEmzz2QhSeplspAk9TJZSJJ6mSwkSb0eP+0AxuWAAw6odevWTTsMSVpSrrnmmu9W1aq55cs2Waxbt45NmzZNOwxJWlKS/O/5yu2GkiT1MllIknqZLCRJvUwWkqReJgtJUi+ThSSpl8lCktTLZCFJ6mWykCT1WrZPcO+K00+/suf40ROKRJJmgy0LSVIvk4UkqZfJQpLUy2QhSeplspAk9TJZSJJ6mSwkSb1MFpKkXiYLSVIvk4UkqZfJQpLUy2QhSeplspAk9TJZSJJ6mSwkSb18n8VOGHzfhe+2kLQS2LKQJPUyWUiSepksJEm9TBaSpF4mC0lSL5OFJKmXyUKS1MtkIUnqZbKQJPXyCe5dNPg0d7fvE92Slh9bFpKkXmNPFkn2SHJdks+3/f2TXJbktva938C5pyXZkmRzkmMHyo9IcmM79oEkGXfckqRHTaJl8Tbg1oH9U4HLq+ow4PK2T5LDgQ3Ac4HjgA8n2aNdczZwEnBY+xw3gbglSc1YxyySrAV+CTgTeEcrPgE4pm2fB1wBnNLKL6iqB4Dbk2wBjkxyB7BPVV3VfvPjwInAJeOMfWc5hiFpORp3y+L9wO8DjwyUHVRVWwHa94GtfA1w58B5d7WyNW17bvljJDkpyaYkm+69997d8h8gSRpjskjyamBbVV0z6iXzlNWQ8scWVp1TVeurav2qVatGvK0kqc84u6GOBl6T5HjgScA+ST4B3JNkdVVtTbIa2NbOvws4eOD6tcDdrXztPOWSpAkZW7KoqtOA0wCSHAO8s6remOS9wEbgrPZ9UbvkYuBTSd4HPJ1uIPvqqno4yfYkRwHfAN4E/Mdxxb27OYYhaTmYxkN5ZwEXJnkL8B3gdQBVdXOSC4FbgIeAk6vq4XbNW4Fzgb3oBrZncnBbkpariSSLqrqCbtYTVfU94OULnHcm3cypueWbgOeNL0JJ0jA+wS1J6mWykCT1MllIknqZLCRJvUwWkqReJgtJUi+ThSSpl8lCktTLZCFJ6mWykCT1MllIknqZLCRJvUwWkqReJgtJUq9pvM9iRfNlSJKWIlsWkqRetiymbLClYStD0qyyZSFJ6mWykCT1MllIknqZLCRJvUwWkqReJgtJUi+ThSSpl8lCktTLZCFJ6uUT3DPMdaQkzQpbFpKkXrYsZsjcloQkzYoFWxZJ9pxkIJKk2TWsG+pvk/x5kpclycQikiTNnGHJ4meATcAfAXcmeX+SF00mLEnSLFkwWVTV96rqI1X1i8CRwO3A+5N8O8mZE4tQkjR1I82Gqqq7gY8CZwPbgd8cZ1CSpNkyNFkkeVKS1yX5LPBt4OXAacDTJxGcJGk2DJsN9SngO8CvA58CnlFVG6vqkqp6uO+HW6K5OskNSW5OckYr3z/JZUlua9/7DVxzWpItSTYnOXag/IgkN7ZjH3DAXZIma9hzFpcCv11V23fytx8AXlZV97dpuF9LcgnwK8DlVXVWklOBU4FTkhwObACeS9dy+XKSZ7XEdDZwEvB14AvAccAlOxnXkuUT3ZKmZdgA93lVtT3JQUk+muSLAEkOT/KWvh+uzv1td8/2KeAE4LxWfh5wYts+Abigqh6oqtuBLcCRSVYD+1TVVVVVwMcHrpEkTcAoA9zn0rUyVrf9vwHePsqPJ9kjyfXANuCyqvoGcFBVbQVo3we209cAdw5cflcrW9O255bPd7+TkmxKsunee+8dJURJ0ghGSRYHVNWFwCMAVfUQ0Dtm0c59uKqeD6ylayU8b8jp841D1JDy+e53TlWtr6r1q1atGiVESdIIRkkWP0zyNNpf0EmOAn6wmJtU1feBK+jGGu5pXUu0723ttLuAgwcuWwvc3crXzlMuSZqQUZLFO4CLgWcmuZJuzOBf9F2UZFWSfdv2XsArgG+139rYTtsIXNS2LwY2JHlikkOBw4CrW1fV9iRHtVlQbxq4RpI0Ab2rzlbVtUleCjybrktoc1U9OMJvrwbOS7IHXVK6sKo+n+Qq4MI2SP4d4HXtPjcnuRC4BXgIOHlgiu5b6cZO9qKbBbXiZkJJ0jQtmCyS7EM3GH1bVT3UprbuBbwwyaVVdc+wH66qbwIvmKf8e3QP9813zZnAY5YSqapNwLDxDknSGA3rhvozYHAi/3uA9cBLgDPGGZQkabYM64b6OeC3B/a3V9W/BEjytbFGJUmaKcOSxePbQ3A7/MbA9r7jCUeL4RPdkiZlWDfUI0l+csdOVd0EkGQN7ZkLSdLKMCxZvBf4yyQvSbJ3+7wU+G/tmCRphViwG6qqPpHku8Cf0C3uV8DNwLuryqmrkrSCDH3Ooqq+CHxxQrFIkmbUSG/KkyStbCYLSVIvk4UkqVfv2lA7JPkF4Ejgpqr60vhC0s4afO7CZy4k7U7D3sF99cD2bwEfBPYG/ri9DlWStEIM64bac2D7JOAfV9UZwCuBN4w1KknSTBnWDfW4JPvRJZRU1b0AVfXDJA9NJDpJ0kwYlix+AriG7h0WleQnq+r/JHkq87/qVJK0TA17gnvdAoceAV47lmi027jIoKTdadjLjzYBV9K9le6KqvoRQFX9P+D2yYSn3cXkIWlXDBvgPgr4HHAM8D+SfCHJ25I8ayKRSZJmxrBuqIeAK9qHJKuBVwF/kuQw4Kqq+p0JxChJmrKRH8qrqq1JzgU+DdwPvHhcQUmSZkvvch9JPpVknyRPAW4BNgP/qqqu7LlUkrRMjNKyOLyq7kvyBuALwCl0U2p9AdIS5oC3pMUYZSHBPZPsCZwIXFRVD443JEnSrBklWXwEuAN4CvDVJM8AfjDOoCRJs2WUZPGXVbWmqo6vqgK+A7x5zHFJkmbIKMniM4M7LWFcMJ5wJEmzaNgT3M8Bngv8RJJfGTi0D/CkcQcmSZodw2ZDPRt4NbAv8MsD5duB3xpjTJKkGTPsCe6LgIuSvLiqrppgTJKkGTPKcxZbkvwBsG7w/KpykFuSVohRksVFwF8BXwYeHm84kqRZNEqyeHJVnTL2SCRJM2uUZPH5JMdX1RfGHo2mxuU/JA0zynMWb6NLGD9Kcl+S7UnuG3dgkqTZ0duyqKq9JxGIJGl2jbJEeZK8Mckftf2Dkxw5wnUHJ/lKkluT3Jzkba18/ySXJbmtfe83cM1pSbYk2Zzk2IHyI5Lc2I59IEl27j9XkrQzRumG+jDdi47+adu/H/jQCNc9RPfei5+he0XryUkOB04FLq+qw4DL2z7t2Aa6p8aPAz6cZI/2W2cDJwGHtc9xI9xfu+D006/8h48kjZIsXlRVJwM/Aqiq/ws8oe+iqtpaVde27e3ArcAa4ATgvHbaeXRLn9PKL6iqB6rqdmALcGR7nes+VXVVW5fq4wPXSJImYJRk8WD7F34BJFkFPLKYmyRZB7wA+AZwUFVthS6hAAe209YAdw5cdlcrW9O255bPd5+TkmxKsunee+9dTIiSpCFGSRYfAD4HHJjkTOBrwL8Z9QZJnkq3cu3bq2rYLKr5xiFqSPljC6vOqar1VbV+1apVo4YoSeoxymyoTya5Bng53V/cJ1bVraP8eHvD3meAT1bVZ1vxPUlWV9XW1sW0rZXfBRw8cPla4O5Wvnaeck2Iz2BIGmU21H8A9q+qD1XVBxeRKAJ8FLi1qt43cOhiYGPb3ki3nMiO8g1JnpjkULqB7KtbV9X2JEe133zTwDWSpAkY5Qnua4F3JXkWXXfUf62qTSNcdzTwG8CNSa5vZX8AnAVcmOQtdG/dex1AVd2c5ELgFrqZVCdX1Y61qN4KnAvsBVzSPpKkCUk3wWiEE5P9gV+lm956SJv6OrPWr19fmzaNktMey+mii2O3lLR8JLmmqtbPLR9lgHuHnwaeQ7dU+bd2U1ySpCVglDGLP01yG/CvgZuAI6rql3sukyQtI6OMWdwOvLiqvjvuYLQ0OVtKWv5G6YY6BzguybsBkhwyytpQkqTlY5Rk8SG6taFe3/a3M9raUJKkZWKUbqgXVdULk1wH3dpQSXrXhpIkLR8TWRtKkrS0jdKymLs21K8B7xprVFrSHPCWlp+xrg0lSVoeRmlZUFXfwgfxJGnFGilZSLtisFvKLilpaVrMch+SpBXKZCFJ6mU3lCbKmVLS0mTLQpLUy2QhSeplspAk9TJZSJJ6mSwkSb2cDaWpcnaUtDSYLDRTTB7SbLIbSpLUy2QhSeplspAk9XLMQjPNMQxpNtiykCT1smWhJcV3Y0jTYbLQkmUXlTQ5dkNJknqZLCRJvUwWkqReJgtJUi8HuLVsOOAtjY8tC0lSL5OFJKnX2JJFko8l2ZbkpoGy/ZNcluS29r3fwLHTkmxJsjnJsQPlRyS5sR37QJKMK2ZJ0vzGOWZxLvBB4OMDZacCl1fVWUlObfunJDkc2AA8F3g68OUkz6qqh4GzgZOArwNfAI4DLhlj3Fom5o5hPPa4YxrSqMaWLKrqq0nWzSk+ATimbZ8HXAGc0sovqKoHgNuTbAGOTHIHsE9VXQWQ5OPAiZgstBu4dIg0uknPhjqoqrYCVNXWJAe28jV0LYcd7mplD7btueXzSnISXSuEQw45ZDeGreXoCj46sGeykIaZlamz841D1JDyeVXVOcA5AOvXr1/wPK1MP54cJC3GpJPFPUlWt1bFamBbK78LOHjgvLXA3a187Tzl0m51zOlv/rH9K07/2JQikWbTpKfOXgxsbNsbgYsGyjckeWKSQ4HDgKtbl9X2JEe1WVBvGrhGkjQhY2tZJDmfbjD7gCR3AX8MnAVcmOQtwHeA1wFU1c1JLgRuAR4CTm4zoQDeSjezai+6gW0HtyVpwsY5G+r1Cxx6+QLnnwmcOU/5JuB5uzE0qZfdUtKP8wluSVKvWZkNJS0ptjy00tiykCT1smUhjWBuS0JaaUwW0m5mF5WWI5OFtBvY8tByZ7KQxsyWhpYDk4WWLdeCknYfZ0NJknrZspAmzG4pLUW2LCRJvWxZSDPGlodmkclCmnGDycPEoWkxWUhT5jMaWgocs5Ak9bJlIS0hfa0Qu6k0LrYsJEm9bFlIy5gzq7S7mCykZaSvm2rYcROJhrEbSpLUy2QhSeplN5QkwJlWGs5koWXDJcnHy8Hylc1kIWmnOFi+spgsJI2drZKlz2Qhabdb7BRek8fsM1lImjpX1p19JgtJM81ZWrPBZCFpSVtMl5bdXzvPZCFppuzq+z12pUvLZLIwk4WkZcsXS+0+JgtJK9ZiZm3NbWUsthWy1AfxTRaSNIJdWdF3sefOYjIxWWjJcnkPaXJMFpI0Y3ZlrGVcrZIls0R5kuOSbE6yJcmp045HklaSJZEskuwBfAh4FXA48Pokh083KklaOZZKN9SRwJaq+l8ASS4ATgBumWpUmjjHKaTpWCrJYg1w58D+XcCL5p6U5CTgpLZ7f5LNO3m/A4Dv7uS142Rci2Nci2NcizOTceWM/7yrcT1jvsKlkiwyT1k9pqDqHOCcXb5Zsqmq1u/q7+xuxrU4xrU4xrU4Ky2uJTFmQdeSOHhgfy1w95RikaQVZ6kki78GDktyaJInABuAi6cckyStGEuiG6qqHkryu8ClwB7Ax6rq5jHecpe7ssbEuBbHuBbHuBZnRcWVqsd0/UuS9GOWSjeUJGmKTBaSpF4miwGztKRIkjuS3Jjk+iSbWtn+SS5Lclv73m9CsXwsybYkNw2ULRhLktNaHW5OcuyE4zo9yd+2ers+yfGTjCvJwUm+kuTWJDcneVsrn2p9DYlr2vX1pCRXJ7mhxXVGK592fS0U11Tra+BeeyS5Lsnn2/7466uq/HTjNnsA3wZ+CngCcANw+BTjuQM4YE7ZvwVObdunAn86oVheArwQuKkvFrrlWG4Anggc2up0jwnGdTrwznnOnUhcwGrghW17b+Bv2r2nWl9D4pp2fQV4atveE/gGcNQM1NdCcU21vgbu9w7gU8Dn2/7Y68uWxaP+YUmRqvp7YMeSIrPkBOC8tn0ecOIkblpVXwX+bsRYTgAuqKoHqup2YAtd3U4qroVMJK6q2lpV17bt7cCtdCsQTLW+hsS1kEnFVVV1f9vds32K6dfXQnEtZGL/3ydZC/wS8J/m3H+s9WWyeNR8S4oM+8M0bgV8Kck1bRkTgIOqait0f/iBA6cW3cKxzEI9/m6Sb7Zuqh3N8YnHlWQd8AK6f5XOTH3NiQumXF+tS+V6YBtwWVXNRH0tEBdM//+v9wO/DzwyUDb2+jJZPGqkJUUm6OiqeiHdSrsnJ3nJFGNZjGnX49nAM4HnA1uBf9fKJxpXkqcCnwHeXlX3DTt1nrJJxjX1+qqqh6vq+XQrMxyZ5HlDTp92XFOtrySvBrZV1TWjXjJP2U7FZbJ41EwtKVJVd7fvbcDn6JqO9yRZDdC+t00rviGxTLUeq+qe9of8EeDPebTJPbG4kuxJ9xfyJ6vqs6146vU1X1yzUF87VNX3gSuA45iB+povrhmor6OB1yS5g66r/GVJPsEE6stk8aiZWVIkyVOS7L1jG3glcFOLZ2M7bSNw0TTiaxaK5WJgQ5InJjkUOAy4elJB7fgD07yWrt4mFleSAB8Fbq2q9w0cmmp9LRTXDNTXqiT7tu29gFcA32L69TVvXNOur6o6rarWVtU6ur+j/ntVvZFJ1Ne4RuuX4gc4nm6WyLeBP5xiHD9FN4PhBuDmHbEATwMuB25r3/tPKJ7z6ZrcD9L9S+Utw2IB/rDV4WbgVROO678ANwLfbH9QVk8yLuAX6Jr53wSub5/jp11fQ+Kadn39LHBdu/9NwLv7/l+fclxTra85MR7Do7Ohxl5fLvchSeplN5QkqZfJQpLUy2QhSeplspAk9TJZSJJ6mSy04iX5n0OO7Zvkdxb5e59rK5JuSfKDgRVKf37OeVe0lUBfM1D2jiTfSrfi8A1J3tceplvoXqcnec+csucnubVtfyXJ/UnWL+a/QZrLZKEVr6p+fsjhfYFFJYuqem11y0T8JvBXVfX89pkvKb2hqi4GSPLP6R7APKqq/hHwc3RP4u415HbnA78+p2wD3YqkVNUvApsWE780H5OFVrwk97fv30vy122RuDPa4bOAZ7aWwXvnXLeutQLOa9d8OsmTdyGUPwTeWt3yElTV31fVWdXWlkryyiRXJbk2yV8keWpVbQa+n+RFA7/zT+iWgpB2G5OFRPcXMd1SCEfSLRJ3RFu88VTg261l8HvzXPps4Jyq+lngPhbZChm4/95070+4fYHjBwDvAl5R3QKTm+jeaQBd62JDO+8o4HtVddvOxCEtxGQhdV7ZPtcB1wLPoUsefe6sqivb9ifoltXYGWFgNdAkx7bWzB1trOMouhfZXNmWzd4IPKOdfgHwa0keR5c0zt/JGKQFPX7aAUgzIsB7quojP1bYvfthmLnr5ezU+jlVdV+SHyY5tKpur6pLgUvTvTbzCS2+y6rq9fNce2dbhfSlwK8CL96ZGKRhbFlInUuBN7f3PZBkTZIDge10ryFdyCFJdvzl/Hrga7sQw3uAswdWOw3wpHbs68DRSX66HXtykmcNXHs+8O/puszu2oUYpHmZLKTuLZpfoptBdFWSG4FPA3tX1ffoun5umjvA3dwKbEzyTWB/upfj7KyzgS8D32i/dyVdt9h1VXUv8M+A89uxr9N1le3wF8BzcWBbY+Kqs1rRkjwNuLaqntF78mOvXUe3RPSwN7sNu/4K4J1VNdaprZO6j5Y3WxZasZI8HbgK+LMphfB3wLmDD+Xtbkm+Qvd+lAfHdQ+tDLYsJEm9bFlIknqZLCRJvUwWkqReJgtJUi+ThSSp1/8HQtzSnMGHp0IAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "## Finally we emulate the trigger selection:\n",
     "\n",
     "## trigger function\n",
     "apply_trigger = lambda x, t: x>t  # is x over threshold\n",
     "\n",
+    "## Define our trigger\n",
+    "thresholds = [200]*len(sigmas) # GeV , #thresholds should equal #sigma values\n",
     "\n",
-    "threshold = 150. # GeV\n",
+    "fig, axes = get_subplots(len(sigmas), 16, 6)                        \n",
     "\n",
-    "# we check if online jet is above trigger threshold\n",
-    "triggered_events = apply_trigger(online_jets_pt, threshold)  \n",
+    "offline_jets_pt_kept_array = []\n",
     "\n",
-    "# we get the offline jets for events in which the trigger fired\n",
-    "offline_jets_pt_kept = offline_jets_pt[triggered_events]     \n",
-    " \n",
-    "print(\"Minimum offline jet pT: \", offline_jets_pt_kept.min())\n",
-    "print(\"Maximum offline jet pT: \", offline_jets_pt_kept.max())\n",
-    "\n",
-    "\n",
-    "plt.hist(offline_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off)\n",
-    "plt.hist(offline_jets_pt_kept,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off_kept)\n",
-    "\n",
-    "plt.ylabel(f\"events/{bin_width} GeV\")\n",
-    "plt.xlabel(\"jet pT [GeV]\")\n",
+    "for idx, online_jets_pt in enumerate(online_jets_pt_array): \n",
+    "    sigma = sigmas[idx]\n",
+    "    threshold = thresholds[idx]\n",
+    "    # we check if online jet is above trigger threshold\n",
+    "    triggered_events = apply_trigger(online_jets_pt, threshold)  \n",
+    "    # we get the offline jets for events in which the trigger fired\n",
+    "    offline_jets_pt_kept = offline_jets_pt[triggered_events]\n",
+    "    offline_jets_pt_kept_array.append(offline_jets_pt_kept)\n",
+    "    axes[idx].hist(offline_jets_pt,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off, label=f\"all events\")\n",
+    "    axes[idx].hist(offline_jets_pt_kept,bins=bins, range=[h_min,h_max], alpha=0.5, color=col_off_kept, label=f\"triggered, thresh={threshold}, $\\sigma$={sigma}\")\n",
+    "    axes[idx].set_ylabel(f\"events/{bin_width} GeV\")\n",
+    "    axes[idx].set_xlabel(\"jet pT [GeV]\")\n",
+    "    axes[idx].legend(loc=\"upper right\")\n",
     "plt.show()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "5ed95714",
    "metadata": {
     "colab": {
@@ -292,34 +270,27 @@
     "id": "5ed95714",
     "outputId": "b1f3c42e-8fae-4b90-e8aa-45723727c509"
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAApf0lEQVR4nO3deXhU9d338fc3C/u+KvtSQNEialS0i1RtK1Sli3WtrT62VK32pstdrV3v2qer7W3vVkWqPrTaW9xoqxardWu1SkvQgKCikEUCKiQkLAmQZb7PH+cEJ2EShjCTM5P5vK4r18xZ5pxPcs3kO7+z/H7m7oiISO7KizqAiIhES4VARCTHqRCIiOQ4FQIRkRynQiAikuMKog5wsIYNG+YTJkyIOobIfratWwfAkGnTIk4isr+VK1dWufvwRMuyrhBMmDCB4uLiqGOI7GfJ7NkAXPDMM5HmEEnEzCraW6ZDQyIiOS7rWgQimerkb3876gginaJCIJIi4884I+oIIp2iQ0MiKbKlpIQtJSVRxxA5aGoRiKTIUwsWADpZLNknbS0CM7vTzLaY2Zp2lpuZ/Y+ZrTez1WZ2XLqyiIhI+9J5aGgxcGYHy+cAU8Kf+cCtacwiknNWVtRw89PrWVlRk7J1u9s2u9vvc7DrtrB0dkNtZhOAR9z96ATLbgOecfd7wul1wGx3f6ujbRZN7u/FPzq+9cxp58HMq6CxHpbO3f9FR10KR18K9VXw8Ln7Lz/mSjjifNixER69JMFOvwaTz4Zt6+BvX9x/+axvw/gzYEsJPL1g/+Xv/xGMPgU2PQ/PXb//8g/dBCNmQsUTsPyH+y//8G0wZBpseBiKf7H/8jl3wYCx8Nq9sCpBPT37AegzDNYshrWL91/+yWVQ2AdKboF19+2//PxngscVN0LpI62XFfSGTz0aPH/hBnjzydbLew+Fcx4Mnj/7Tdj8Quvl/cfA3LuD508vCP6G8QZPhY8sCp4/Ph9qXm+9fMTM4O8HsOwzsLOy9fJRJ8MHfhw8f+hTsLu69fJxp8PJ3wmePzgHmna3Xj7pLDjh68Hze2ezn7j33pbvjgojzXx3eQTvPQeqdu2ldGsdP9v1WVbFprNg+hbm7bplv5c/c/j1rG6YwDtr/sJVvZZgZgzr14MeBcF3xCdG/xc1PScxacdTvPftO6ja1YC771vvyQk3sqvH4UytXcYx2+7Zt92GphhVuxq4cvt17LBB/N8pxZyy95H99n/r4F9x36oaLuzxCGf1eq7VvgHun3QXAMdvvYMxNU+12v/A/v1ZNuVOAE565xbG1b3Qat/bYv25Zte3+MSxo/j07ls4vL6k1b63+nDO2/glmmPOd/v9lg8Oqmy175oeE3hizA0AnFJ6PVb7RqvffXu/o3hmVPB5nrPxP+nX+Pa+fbs7Jc1HsmHa9Rw+sDdnV1xDr+baVvt/paCIL5WeRXPMWTzwe4zpT6v9l/afzcrhl/PW9t2cu+GzrfbdoyCP1wfOYdXQiyiI7eYT5fNb/e7uztKGM/Dpn2Ni3z2c/eaXGXflipXuXrT/myjacwSjgY1x05XhvP0KgZnNJ2g1MGNMzy4JJ5Kpdu5pYseeRgb0KqRvzCnfuouKdVuYWF1P3d4m6hqaiMWCL3gONMWcp16roqjf7v22dU/lRl5pKuR9hcG0u7N1516wYPruyjcpbY5xeo+3OKzX3n2va1lv8QvlvBWr42M93mZY77jt+7sPTTFnRXkN43vvv/+l5ZtpoheeYN8Av356PQBf6F3NaYWt9//2jr37ltO7mvweu1vtm3Df96/cxMS+NRxX2Hr/bzXX09Tyd0qw77LmHfz6jWD7h/WtY1J+63Vfqa3l1+uC5ZP67eSw/N2t9h3zYN9mcGT/Ogbntd7/moYd7+4f9tv/P7dU89s163GHTw3cP+cz72zl7j3r6cUeThy4/+8ei8EDKzcxJG87xw3Y/28fL8oWwV+AH7v7c+H0k8A33H1lR9ssKipy3VksmWjT888DMPqUU9K2j5UVNVy4aDmNzTHMoFdhPvUNzQD0KszjqFEDmTFmIAN6FbDw76U0NccoLMjjD5+fxfHjB7e7zYtvX05jU8frJrtetmyzu/0+B1rXzNptEWTfoSEVAslhC5a8xJ9KNu+bPmbMQC46aRwzxgxiyoh+FOS/e2hhZUUNy0urmTVpaLv/OA523e62ze72+3S0bqYWgo8BVwNzgZOA/3H3Ew+0TRUCyVTpbhG8/s5Ozvn1c+xtjpEHB/x2KBKvo0KQtnMEZnYPMBsYZmaVwPeAQgB3XwgsIygC64F64LJ0ZRHpCs9eH5w4TMd9BLX1DXzh98X0713Irz/+Xl7fsjOpb4ciyUhbIXD3Cw+w3IEvpWv/It1FU3OMa+55ibdq93DP/KAF8OGjRkYdS7oR3VkskuF++tfXePaNKn76qfeqBSBpob6GRDLY0hcr+e2zZXzu5PGcf8K4qONIN6VCIJKhVlfWct3Sl5k1aQjfPmt61HGkG9OhIZEUOe2mm1K2rS079zD/9ysZ3q8nN190HIX5+s4m6aNCIJIirbqWOAR7m5q58u4Xqd3dwINXnsLQfrqbXtJLhUAkRSqeeAI4tAFq3J3v/XktKytq+M1Fx3LUqIGpiifSLhUCkRR54YdBh4GHUgjuXl7BkhUbuWr2ZM6aMSpV0UQ6pEIgkgFWVtRwf/FG7i/eyGlHjOBrH5kWdSTJISoEIhFbWVHDRb9dzt6mGAZc9r4J5OfZAV8nkiq6FEEkYstLq2loigFgBqsrt0ecSHKNCoFIxGZNGoqFDYAeBXnMmjQ02kCSc3RoSCRFPnLbbZ163bFjB9GrMJ/3jOjH984+St1ISJdTIRBJkSHTOneCt7y6jvqGZi4+aZyKgERCh4ZEUmTDww+z4eGHD/p1qyprAZgxZlBqA4kkSS0CkRRZ8YtfADD57LMP6nWrNm6nd2E+U0b0S0cskQNSi0AkYqsqazl69IBWw0yKdCW980Qi1NgcY+3mHRyjw0ISIRUCkQite3snDU0xjhk7KOooksNUCEQiVLKxFkAtAomUThaLpMjcu+466NesrqxlcJ9Cxg7pnYZEIslRIRBJkQFjxx70a1Zt3M4xYwdhpr6FJDo6NCSSIq/dey+v3Xtv0uvX7W3ijS07df+ARE4tApEUKbn1VgCOOP/8pNZfs2k7MYeZYzX4jERLLQKRiLT0MqoWgURNhUAkIiWVtYwe1JthGpNYIqZCIBKRVRtrman7ByQDqBCIRKB6114qa3YzY4zOD0j0dLJYJEXOeeCBpNdtOT+gO4olE6gQiKRIn2HDkl53VWUtZnD0aLUIJHo6NCSSImsWL2bN4sVJrbtqYy1TRvSjX099F5PoqRCIpEiyhcDdWVW5Xf0LScZIayEwszPNbJ2ZrTez6xIsH2hmD5vZKjNba2aXpTOPSCaorNnNtroGZuj8gGSItBUCM8sHbgbmANOBC81sepvVvgS84u7HALOBX5hZj3RlEskELUNTzlSLQDJEOlsEJwLr3b3U3RuAJcC8Nus40N+CHrf6AduApjRmEonc6srt9MjPY9ph/aOOIgKktxCMBjbGTVeG8+L9BjgS2Ay8DPyHu8fabsjM5ptZsZkVb926NV15RbpEycZapo8aQI8CnaKTzJDOSxYS9avrbaY/CpQApwGTgb+Z2bPuvqPVi9wXAYsAioqK2m5DJCN8atmyA67THHPWbNrOeUUH32W1SLqk8ytJJRD/bh9D8M0/3mXAUg+sB8qAI9KYSSRtCvv0obBPnw7XWb9lF/UNzbqjWDJKOgvBCmCKmU0MTwBfADzUZp03gdMBzGwkMA0oTWMmkbR56ZZbeOmWWzpcZ1XL0JS6YkgySNoODbl7k5ldDTwG5AN3uvtaM7siXL4QuAFYbGYvExxKutbdq9KVSSSd1t13HwDHXnVVu+usqqylf68CJg7t21WxRA4orbc1uvsyYFmbeQvjnm8GPpLODCKZZFVlLTPGDCQvT0NTSubQZQsiXWRPYzOvvbVTdxRLxlEhEOkir7y1g6aYa0QyyTgqBCJdpOVEsQajkUyjrg9FUuSCZ57pcPnqyu2MHNCTwwb26ppAIklSi0Cki6zaWKvDQpKRVAhEUmTFjTey4sYbEy7bvruR0qo6HRaSjKRCIJIiGx55hA2PPJJw2cvh0JS6o1gykQqBSBdo6Xp6xuhBkeYQSUSFQKQLrNpYy6RhfRnYpzDqKCL7USEQ6QItdxSLZCJdPiqSIgW9eyec//b2PbyzY686mpOMpUIgkiLnPvpowvn7zg/o0lHJUAc8NGRmD5rZx8xMh5FEOmHVxloK8oyjRg2IOopIQsn8c78VuAh4w8x+YmYaOEYkgRduuIEXbrhhv/mrK7dzxOH96VWYH0EqkQM7YCFw9yfc/WLgOKCcYDjJ583sMjPTJRAioYonn6TiySdbzYvFPDxRPCiaUCJJSOpwj5kNBS4FPg+8BPyKoDD8LW3JRLqB8uo6du5pYqYKgWSwA54sNrOlBOMI3wWc7e5vhYvuNbPidIYTyXYtJ4p1xZBksmSuGvqNuz+VaIG7F6U4j0i38rdX3qEw39ixpzHqKCLtSubQ0JFmNqhlwswGm1n7g7KK5KjeQ4fSe+jQfdMrK2p4dM3bNDY7l9zxL1ZW1ESYTqR9yRSCL7h7bcuEu9cAX0hbIpEsNe/BB5n34IP7pl/YUIV78LyxKcby0uqIkol0LJlCkGdm+0baNrN8oEf6Iol0D1NH9gfAgMKCPGZNGtrxC0Qiksw5gseA+8xsIeDAFcBf05pKJAv945vfBOCDP/4xAP16Bh+vTxeN4fwTxnH8+MGRZRPpSDKF4Frgi8CVBF9uHgduT2cokWy0+YUXWk2XVdcBsOCMqYwalLgfIpFMcMBC4O4xgruLb01/HJHuo2xrHT0L8jhsgMYolsyWzH0E7wO+D4wP1zfA3X1SeqOJZLfy6jomDutLXp4deGWRCCVzaOgO4CvASqA5vXFEuo+yqjqmjOgfdQyRA0qmEGx398T964rIPv3HjNn3vKk5xpvb6vnw9MMiTCSSnGQKwdNm9nNgKbC3Zaa7v5i2VCJZ6GN3373v+ebaPTQ2O5OG9Y0wkUhykikEJ4WP8d1JOHBa6uOIdA+lVbsAmKBCIFkgmauGPtQVQUSy3VMLFgBw2k03UV4VXDo6UYVAskAyI5SNNLM7zOzRcHq6mV2ezMbN7EwzW2dm683sunbWmW1mJWa21sz+fnDxRTLHlpIStpSUAFBeXU+/ngUM66eb8CXzJdPFxGKCu4tHhdOvAwsO9KKwK4qbgTnAdOBCM5veZp1BwC3AOe5+FPDpJHOLZLTSquDS0bjeWUQyVjKFYJi73wfEANy9ieQuIz0RWO/upe7eACwB5rVZ5yJgqbu/GW57S9LJRTJYeVWdzg9I1kimENSFI5Q5gJnNArYn8brRwMa46cpwXrypwGAze8bMVprZZxNtyMzmm1mxmRVv3bo1iV2LRKehKUZlTT0Th/aJOopIUpK5auirwEPAZDP7JzAcODeJ1yVqE3uC/R8PnA70Bl4ws+Xu/nqrF7kvAhYBFBUVtd2GSEYYMnUqAG9uqyfmMHG4WgSSHZK5auhFMzsVmEbwz32duycz3FIlMDZuegywOcE6Ve5eR9Dy+AdwDMF5CJGs8pFFi4BgVDKACUNVCCQ7tHtoyMxOCx8/CZxDUAimAmeH8w5kBTDFzCaaWQ/gAoKWRbw/Ax8wswIz60Nwz8KrB/9riGQOXToq2aajFsGpwFPA2QmWOcGdxu1y9yYzu5rgiqN84E53X2tmV4TLF7r7q2b2V2A1wcno2919TSd+D5HIPT5/PgBlc65hcJ9CBvXRpaOSHdotBO7+vfDxss5u3N2XAcvazFvYZvrnwM87uw+RTLHt9eCIZllRnVoDklWSuaHsRwkGr/9hWlOJZLHyal06KtklmctH5yQYvH5u2hKJZLGYO29t38NEnSiWLJJMIcg3s54tE2bWG+jZwfoiOWtPYwzQpaOSXZK5j+Bu4Ekz+38EJ4n/D/C7tKYSyUIjZs7cd8WQLh2VbJLMfQQ/M7OXCW76MuAGd38s7clEssxpN93EzU+vh8fW6WSxZJVkWgSEI5RplDKRAyivqmNE/5707ZnUR0skI3R0Q9lz4eNOM9sR97PTzHZ0XUSR7PCXz3yGvJ9/Q60ByTodfW35LIC7a/RtkSTsrKzEt9aoEEjW6eiqofsBzOzJLsoiktWaY05jc0z3EEjW6ahFkGdm3wOmmtlX2y5091+mL5ZI9tnTGAzToRaBZJuOWgQXAHsIikX/BD8iEkeFQLJVRy2CM939p2bW091/0GWJRLLUnikzeLtwG+OGaEAayS4dtQhaOpv7eBfkEMl6G+ddwZvzrqRXYX7UUUQOSkctglfNrBwYbmar4+Yb4O4+I63JRLJMWVUdk9S1hGShjrqhvtDMDiMYT+Ccroskkn3cnXG3XMeogb3h8r9FHUfkoHR4+6O7vw0cE3Y0N87d13VNLJHssq2ugYJd2+ndsynqKCIHLZnxCM4GSoC/htMzzaztkJMiOa28OuhsTucHJBsl0w3194ETgVoAdy8BJqQrkEg2Kt3aUgiS+UiJZJZk3rVN7r497UlEslh5dR1mRs8CtQgk+yTTReIaM7uIYICaKcCXgefTG0sku5RX1dNwRBET3j8x6igiBy2ZFsE1wFHAXuB/ge3AgjRmEsk6pVV1NF94JSd/5ztRRxE5aMkMTFMPfCv8EZE23J3yqjpOnjQ06iginaIzWyKH6J0de9nd2MygH13FA3PmRB1H5KBpGCWRQ1QWjlPcM9ZI0+6Iw4h0QoctAjPLN7OvdFUYkWykewgk23VYCNy9GZjXRVlEslJZVR09CvLoWaAjrZKdkjk09E8z+w1wL1DXMtPdX0xbKpEsUlZVx4Sh6npaslcyheCU8DF+TAIHTkt9HJHsU1ZVx+ThfZl81llRRxHplGQuH/1QVwQRyUbNMefN6npOP3IEJ1zy9ajjiHRKMp3OjTSzO8zs0XB6upldnv5oIplvc+1uGppjTByqcQgkeyVzdmsxwZgEo8Lp19GdxSLAu5eOThzWlyWzZ7Nk9uxoA4l0QjKFYJi73wfEANy9CWhOZuNmdqaZrTOz9WZ2XQfrnWBmzWZ2blKpRTJEy6WjGrBeslkyhaDOzIYSnCDGzGYR9DfUITPLB24G5gDTgQvNbHo76/2UoNUhklVKt9bRt0c+w/v3jDqKSKclc9XQV4GHgMlm9k9gOJDMN/cTgfXuXgpgZksI7kl4pc161wAPAickG1okU5RX1zFhWF/MLOooIp2WzFVDL5rZqcA0goHr17l7YxLbHg1sjJuuBE6KX8HMRgOfILgUtd1CYGbzgfkA48aNS2LXIl2jrKqO944eGHUMkUNywEJgZp9sM2uqmW0HXnb3LR29NME8bzN9E3Ctuzd39I3K3RcBiwCKiorabkMkEg1NMSprdnPOMcF1FNPOOy/iRCKdk8yhocuBk4Gnw+nZwHKCgvADd7+rnddVAmPjpscAm9usUwQsCYvAMGCumTW5+5+SSi8SoY019TTHnAnhpaPHXnVVxIlEOieZQhADjnT3dyC4rwC4leAwzz+A9grBCmCKmU0ENgEXABfFr+Du+4ZzMrPFwCMqApItylsuHR0eFILG+noACvuouwnJLskUggktRSC0BZjq7tvMrN1zBe7eZGZXE1wNlA/c6e5rzeyKcPnCQwkuErV99xCELYIH584F4IJnnokqkkinJFMInjWzR4D7w+lPAf8ws75AbUcvdPdlwLI28xIWAHe/NIksIhmjrKqOQX0KGdy3R9RRRA5JMoXgSwT//N9HcAL498CD7u6A+iGSnFVeXbfv/IBINkvm8lEHHgh/RCRUtrWOWRqnWLqBZC4f3cn+l31uB4qBr7XcMCaSS/Y0NrN5+x4mqGsJ6QaSOTT0S4LLPv+X4NDQBcBhwDrgToLLSUVySksfQ/GF4OhLL40ojcihSaYQnOnu8XcELzKz5e7+AzO7Pl3BRDJZy6Wjk1QIpBtIptO5mJmdZ2Z54U/87ZO6y1dyUllVcM9AfIugvqqK+qqqqCKJdFoyheBi4BKC+wfeCZ9/xsx6A1enMZtIxiqr2sXw/j3p1/PdRvVD557LQ+eqJ3XJPslcNVQKnN3O4udSG0ckO5RX1WtUMuk22i0EZvYNd/+Zmf2aBIeA3P3LaU0mksFKq+o4/YgRUccQSYmOWgSvho/FXRFEJFvs3NNI1a69unRUuo12C4G7PxyOHna0u/9nF2YSyWh/XfM2AO6xiJOIpEZHh4YKwo7jju/KQCKZbGVFDdf/8WUAfvXkek6aNIzjxw8GYOaVV0YZTaTTOjo09G/gOOAlM3uIoNO5upaF7r40zdlEMs7y0mqamoNTZk3NMZaXVu8rBEecf36U0UQ6LZkbyoYA1QTDSTrB3cUOqBBIzpk1aei+T0BhQV6rvoZ2bAxGZh0wdmw7rxbJTB0VghFm9lVgDe8WgBa6kUxy0rTD+oPDyZOG8PWPHrGvNQCw7JJLAI1HINmno0KQD/QjubGHRXJCyZu1OHDl7Pe0KgIi2ayjQvCWu/+gy5KIZIEV5dvIMzh23KCoo4ikTEddTCRqCYjktOKKbRx5+AD69yqMOopIynRUCE7vshQiWaCxOcaLFbWcMGFI1FFEUqqjG8q2dWUQkUz3yuYd7G5sbrcQnPC1r3VxIpHUSObyUREhOD8AUDQh8UniyWe31zejSGZLphtqEQGKy2sYN6QPIwf0Srh827p1bFu3rotTiRw6tQhEkuDuFFds44NTh7e7zuNf/CKg+wgk+6hFIJKE8up6qnY16ESxdEsqBCJJWFEWnB84oZ3zAyLZTIVAJAkryrcxuE8hk4f3izqKSMqpEIgkobiihqIJQzDTfZbS/ehkscgBbN25l7KqOi48seNeRU/+9re7KJFIaqkQiBzAyoqW+wc6PlE8/owzuiKOSMrp0JDIAawor6FnQR5HjxrY4XpbSkrYUlLSNaFEUiithcDMzjSzdWa23syuS7D8YjNbHf48b2bHpDOPSGcUl29j5thB9Cjo+OPy1IIFPLVgQdeEEkmhtBWCcOD7m4E5wHTgQjOb3ma1MuBUd58B3AAsSlcekc6o29vEms07dP+AdGvpbBGcCKx391J3bwCWAPPiV3D35929JpxcDoxJYx6Rg1aysZbmmHPCRBUC6b7SWQhGAxvjpivDee25HHg00QIzm29mxWZWvHXr1hRGFOlYy0A0x2kgGunG0lkIkh7i0sw+RFAIrk203N0XuXuRuxcNH95+Xy8iqVZcXsMRh2kgGune0nn5aCUQf+H1GGBz25XMbAZwOzDH3avTmEfkoDQ1x3jxzRo+fXxyRyw/8KMfpTmRSHqksxCsAKaY2URgE3ABcFH8CmY2DlgKXOLur6cxi8hBe/WtndQ3NB/w/oEWo085Jc2JRNIjbYXA3ZvM7GrgMSAfuNPd15rZFeHyhcB3gaHALeGt+03uXpSuTCIH498HGIimrU3PPw+oIEj2Seudxe6+DFjWZt7CuOefBz6fzgwinVVcvo0xg3tz+MDeSa3/7PXXAxqPQLKP7iwWScDdWVFew4m6f0BygAqBSAIV1fVU7dqb9PkBkWymQiCSQMtA9RqIRnKBCoFIAsXlNQzSQDSSI9QNtUgCK8q3UTR+MHl5yQ9Ec9pNN6UvkEgaqRCItFG1ay+lVXWcd0LHA9G0NWLmzPQEEkkzHRoSaaO4POgH8WDPD1Q88QQVTzyRjkgiaaUWgUgbxeXbgoFoRnc8EE1bL/zwh4BGKpPsoxaBSBsrKmo4ZuwgehbkRx1FpEuoEIjEqW9oYu2m7bpsVHKKCoFInJKNtTTFXDeSSU5RIRCJs6KsBjM4bpxaBJI7dLJYJE5xxTamjezPwN4HPxDNR267LQ2JRNJPhUAk1NQc48WKGj55XOeGzh4ybVqKE4l0DR0aEgm99vZO6hqaOz1Q/YaHH2bDww+nOJVI+qlFIBJa+mIlAL0KOvf9aMUvfgHA5LPPTlkmka6gFoEIsLKihsXPlwPw5SUvsbKiJtpAIl1IhUAE+MvLm4l58LyxKcby0upoA4l0IRUCyXl7m5p56tUtAOQbFBbkMWvS0IhTiXQdnSOQnHfjY+sor67nm3OOoCnmzJo0lOPH6z4CyR0qBJLTnnujit8+W8Yls8bzxVMnH9K25t51V4pSiXQtFQLJWTV1DXz1vhLeM6If18898pC3N2DswY1fIJIpdI5AcpK7c93S1dTUN/CrC2bSu8eh9zT62r338tq996YgnUjXUotActK9Kzby2Np3+NbcIzlq1MGNO9CekltvBeCI889PyfZEuopaBJJzSrfu4r8efoX3v2cYl79/YtRxRCKnQiA5paEpxn8sKaFnYR6/OO+YgxqcXqS70qEhySn//cTrvLxpOws/czwjB/SKOo5IRlCLQHLGCxuqWfj3DVx44ljOPPqwqOOIZAy1CCQnbK9v5Kv3lTBxaF++c9b0tOzjnAceSMt2RdJNhUC6PXfn+j++zNade1l61Sn06ZGet32fYcPSsl2RdFMhkG5tZUUNtz9byqNr3uYbZ05jxphBadvXmsWLATj60kvTtg+RdEhrITCzM4FfAfnA7e7+kzbLLVw+F6gHLnX3F9OZSbq/7fWNrN+6kydeeYdFz5bRHHPyDE5I84D0KgSSrdJWCMwsH7gZ+DBQCawws4fc/ZW41eYAU8Kfk4Bbw8ekrayoYXlpdVIdhSW7rraZHdt86rV3GDmgF2bG+nd28saWXbyxZRdbd+5N+Jp/l21LezEQyUbpbBGcCKx391IAM1sCzAPiC8E84Pfu7sByMxtkZoe7+1vtbfT1d3by4V/+HYDdjc1sqtmNAwaMHtyb3oWJuwpIdl1tM3O2ObRfD/LzjOYYNMdiNMWc5pjT2ByjsdlbvbZvj3zeM7I/p04dzpQR/Zgysh97G2N85b4SGpti6lpapAPpLASjgY1x05Xs/20/0TqjgVaFwMzmA/MBBoyaxJSR/QBYv2UXLf8OHOjTI5/3jOiXMEyy62qbmbPNkQN6cfSogeTnGwV5Rp4Fj6s31bKirAYH8gzmf3AS1555BMGRxtZGDOiVdGtEJFelsxAkumXTO7EO7r4IWARQVFTkt1x8PBAcHrj49uX7vvH9+JMz2v2wJ7uutpk52/zBvKOT2uaHpx+WsAgAHD9+sAqAyAFYcFQmDRs2Oxn4vrt/NJz+JoC7/zhunduAZ9z9nnB6HTC7o0NDRUVFXlxcvG86m45pa5vRbLOrNNbXA1DYp0/ESUT2Z2Yr3b0o4bI0FoIC4HXgdGATsAK4yN3Xxq3zMeBqgquGTgL+x91P7Gi7bQuBiIgcWEeFIG2Hhty9ycyuBh4juHz0Tndfa2ZXhMsXAssIisB6gstHL0tXHpF0e+mWWwA49qqrIk4icnDSeh+Buy8j+GcfP29h3HMHvpTODCJdZd199wEqBJJ91OmciEiOUyEQEclxKgQiIjlOhUBEJMel7fLRdDGzrUBFijc7DKhK8TbTQTlTSzlTJxsyQm7nHO/uwxMtyLpCkA5mVtze9bWZRDlTSzlTJxsygnK2R4eGRERynAqBiEiOUyEILIo6QJKUM7WUM3WyISMoZ0I6RyAikuPUIhARyXEqBCIiOS7nCoGZfcXM1prZGjO7x8x6mdkQM/ubmb0RPkbSwb2Z3WlmW8xsTdy8drOZ2TfNbL2ZrTOzj0aY8edm9pqZrTazP5rZoCgztpczbtnXzczNbFim5jSza8Isa83sZ5mY08xmmtlyMysxs2IzOzFuWRTvzbFm9rSZvRr+3f4jnJ9pn6H2ckb3OXL3nPkhGAazDOgdTt8HXAr8DLgunHcd8NOI8n0QOA5YEzcvYTZgOrAK6AlMBDYA+RFl/AhQED7/adQZ28sZzh9L0DV6BTAsE3MCHwKeAHqG0yMyNOfjwJzw+VyCQaaifG8eDhwXPu9PMB7K9Az8DLWXM7LPUc61CAi63u4dDpzTB9gMzAN+Fy7/HfDxKIK5+z+AbW1mt5dtHrDE3fe6exnBmA4dDuqTrozu/ri7N4WTy4ExUWZsL2fov4Fv0HpI1EzLeSXwE3ffG66zJUNzOjAgfD6Q4LMUWU53f8vdXwyf7wReJfjyl2mfoYQ5o/wc5VQhcPdNwI3Am8BbwHZ3fxwY6eHwmOHjiOhS7qe9bKOBjXHrVYbzovZ/gEfD5xmV0czOATa5+6o2izIqJzAV+ICZ/cvM/m5mJ4TzMy3nAuDnZraR4HP1zXB+5DnNbAJwLPAvMvgz1CZnvC79HOVUIQiPDc4jaF6NAvqa2WeiTdVpiUZrj/RaYDP7FtAE/KFlVoLVIsloZn2AbwHfTbQ4wbwo/5YFwGBgFvCfwH1mZmReziuBr7j7WOArwB3h/Ehzmlk/4EFggbvv6GjVBPMizxnF5yinCgFwBlDm7lvdvRFYCpwCvGNmhwOEj1s62EZXay9bJcHx7hZjeLdp3uXM7HPAWcDFHh7YJLMyTib4ArDKzMrDLC+a2WFkVk4I8iz1wL+BGEEnZJmW83MEnyGA+3n3cEVkOc2skOCf6x/cvSVbxn2G2skZ2eco1wrBm8AsM+sTfsM6neD43EMEb2rCxz9HlC+R9rI9BFxgZj3NbCIwBfh3BPkwszOBa4Fz3L0+blHGZHT3l919hLtPcPcJBB+u49z97UzKGfoTcBqAmU0FehD0RJlpOTcDp4bPTwPeCJ9HkjP8TN8BvOruv4xblFGfofZyRvo5SvcZ8kz7Af4LeA1YA9xFcCZ+KPAkwRv5SWBIRNnuITh30Ujwj+ryjrIRHOrYAKwjvHojoozrCY5hloQ/C6PM2F7ONsvLCa8ayrScBP/47w7foy8Cp2VozvcDKwmuaPkXcHzE7833ExwyWR33XpybgZ+h9nJG9jlSFxMiIjku1w4NiYhIGyoEIiI5ToVARCTHqRCIiOQ4FQIRkRynQiBZw8y+HPbY+Ifwmuonwp4vzzezZ8ysKFxvWXzPjYewv3PM7LoDrDPbzE45iG2+N8xcYmbbzKwsfP5Em/UmmNluMyuJmzfSzP7XzErNbKWZvWBmnzjA/srMbFqbeTeZ2TfM7ANm9ool6KFVcktB1AFEDsJVBNdQl5nZLKDQ3WcCmNmVLSu5+9xU7MzdHyK4macjs4FdwPNJbvNlYCaAmS0GHnH3B9pZfUPc72cEN5r9zt0vCueNB845wC6XABcQ3D+DmeUB5wLvc/cKM5sLPJJMdum+1CKQjGNmX7VgvIg1ZrYgnLcQmAQ8ZGbXEtxwNTP8Nj25zevLzWxY+K36VTP7bdjv++Nm1jtcZ7KZ/TX8Zv2smR2RIMelZvab8PlwM3vQzFaEP+8LOwy7AvhKmOMDbV7/fTO7y8yesqAv/C8cwp/lNKDB3Re2zHD3Cnf/dbivfAv6s19hQX/2XwxXu4egELT4IFDu7hWHkEW6GbUIJKOY2fHAZcBJBJ1t/cvM/u7uV4S34H/I3avM7F/A1939rPB17W1yCnChu3/BzO4DPkVQRBYBV7j7G2Z2EnALYbcO7fgV8N/u/pyZjQMec/cjwwK1y91vbOd1Mwg6j+sLvGRmf3H3zvQTcxTBXcbtuZygN90TzKwn8E8ze9zdV5tZzMyO8aDX1QsIioPIPioEkmneD/zR3esAzGwp8AHgpU5ur8zdS8LnK4EJFvT6eApwf1wB6XmA7ZwBTI9bf4CZ9U9i/392993AbjN7mqBjtj8lHz8xM7uZ4G/V4O4nEAxqMsPMzg1XGUhQBMsIWwVmtpag991EPbBKDlMhkEzT7lf7Ttob97wZ6E1wSLS25fh7kvKAk8N/6vt00BJp0bYPl8726bKWoDUTbMT9SxYMtVncEgW4xt0fS/DaewhGE/s7sNrfHehGBNA5Ask8/wA+bkEPsX2BTwDPpnIHHvT9XmZmn4bgRKyZHXOAlz0OXN0yYWYzw6c7CYYbbM88C8bFHkpwYnlFJ2M/BfSKPylOMMJei8eAKy3o3hgzmxr+/XD3DUA18BN0WEgSUCGQjOLBEH6LCbrZ/Rdwu7t39rBQRy4GLjezVQTftue1Fyl8/DJQFJ6IfYXgJDHAw8AnEp0sDv0b+AvB0IM3dPL8AB70Dvlx4NTwktB/Ewy7eG24yu3AKwRjLKwBbqN1i/8e4Ajgj53Zv3Rv6n1UpB1m9jVggLt/r5Ov/z4dn0ju6LUTCC4tPboz+860/UhmU4tAJAEzuwK4lOAKoyg0AwPjbyhLtbAF8zDBoDeSw9QiEBHJcWoRiIjkOBUCEZEcp0IgIpLjVAhERHKcCoGISI77/6UpYHuYjuPAAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Now we plot our trigger turn-on: We plot triggered events/total events per bin. \n",
+    "fig, ax = plt.subplots()\n",
     "\n",
-    "cnt_total,edges = numpy.histogram(offline_jets_pt, bins=bins, range=[h_min,h_max])\n",
-    "cnt_kept,edges = numpy.histogram(offline_jets_pt_kept, bins=bins, range=[h_min,h_max])\n",
+    "eff_array=[]\n",
     "\n",
-    "eff = cnt_kept/cnt_total\n",
-    "centered_pt = (edges+bin_width*0.5)[:-1] # recompute bin edges to plot center of pT bin vs efficiency\n",
+    "for idx, offline_jets_pt_kept in enumerate(offline_jets_pt_kept_array): \n",
+    "    sigma=sigmas[idx]\n",
+    "    cnt_total,edges = numpy.histogram(offline_jets_pt, bins=bins, range=[h_min,h_max])\n",
+    "    cnt_kept,edges = numpy.histogram(offline_jets_pt_kept, bins=bins, range=[h_min,h_max])\n",
+    "    eff = cnt_kept/cnt_total\n",
+    "    eff_array.append(eff)\n",
+    "    centered_pt = (edges+bin_width*0.5)[:-1] # recompute bin edges to plot center of pT bin vs efficiency\n",
+    "    ax.plot(centered_pt, eff, marker=\".\", label=f\"$\\sigma$={sigma}\")\n",
     "\n",
-    "plt.plot(centered_pt, eff, marker=\".\")\n",
-    "\n",
-    "plt.xlim(threshold*0.5-sigma, threshold*1.5+sigma)\n",
-    "plt.axvline(threshold,0,1.0, linestyle='--', color='darkred')\n",
-    "plt.axhline(1.0,0,threshold*1.5+sigma,linestyle='--', color='darkorange')\n",
+    "ax.legend(loc=\"lower right\")\n",
+    "plt.xlim(threshold*0.5-max(sigmas), threshold*1.5+max(sigmas))\n",
+    "for threshold in thresholds:\n",
+    "    plt.axvline(threshold,0,1.0, linestyle='--', color='darkred')\n",
+    "plt.axhline(1.0,0,threshold*1.5+max(sigmas),linestyle='--', color='darkorange')\n",
     "\n",
     "\n",
     "plt.ylabel(f\"Trigger efficiency\")\n",
@@ -334,18 +305,32 @@
     "id": "g1-aGesD67_J"
    },
    "source": [
-    "## Measuring jet trigger performance\n",
+    "### Trigger turn-on analysis\n",
     "\n",
-    "You can see that\n",
+    "As reference, here is an ATLAS public plot of single jet trigger turn-ons at 420 GeV threshold (with some variations),\n",
+    "<img src=\"https://twiki.cern.ch/twiki/pub/AtlasPublic/JetTriggerPublicResults/eff_PT_j420_data17-data18.png\" width=\"400\" />\n",
+    "\n",
+    "Our generated plot has the same features as in the ATLAS plot. \n",
+    "You can see that:\n",
     "\n",
     "(1) The trigger turn-on is not a step function at threshold: There is a gradual turn on of the trigger efficiency, reaching 100% after the trigger threshold.\n",
     "\n",
     "(2) We eventually reach 100% trigger efficiency once the offline jet pT is high enough.\n",
     "\n",
+    "**Question**: How does the turn-on change with different sigma values? We can simply add more sigma values to the list above and plot a comparison...\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd89d358",
+   "metadata": {},
+   "source": [
+    "## Measuring jet trigger performance\n",
+    "\n",
     "Analysis using hadronic jets typically ensure that they are working in a region where the trigger is almost 100% efficient, by simply selecting events where the leading offline jet pT is greater than the point where the trigger turn-on curve reaches 99%. This means, events collected below the 99% turn-on point are wasted rate. \n",
     "\n",
     "One can measure the performance of the trigger by (1) measuring the jet pT @ 99% turn-on and (2) measuring the fraction of events that are wasted. \n",
-    "A good trigger will have a 99% turn-on that is close to threshold, and as little"
+    "A good trigger will have a 99% turn-on that is close to threshold, and as little as possible wasted rate."
    ]
   },
   {
@@ -363,46 +348,57 @@
    "source": [
     "## Measuring jet trigger performance\n",
     "\n",
-    "pt_at_99 = centered_pt[eff>=0.99][0]\n",
-    "total_events_triggered = offline_jets_pt_kept.size\n",
-    "total_events_for_physics = offline_jets_pt_kept[offline_jets_pt_kept>=pt_at_99].size\n",
-    "wasted_frac = (total_events_triggered-total_events_for_physics)/total_events_triggered\n",
+    "total_events = samples\n",
     "\n",
-    "print(\"99%% trigger efficiency @ jet pT = %i GeV \"%(pt_at_99))\n",
-    "print(\"Number of triggered events = \", total_events_triggered)\n",
-    "print(\"Number of events for analysis = \", total_events_for_physics)\n",
-    "print(\"fraction of wasted events = %.2f\"%(wasted_frac))"
+    "for idx,eff in enumerate(eff_array):\n",
+    "    sigma = sigmas[idx]\n",
+    "    threshold = thresholds[idx]\n",
+    "    offline_jets_pt_kept = offline_jets_pt_kept_array[idx]\n",
+    "    # get first jet pT where trigger efficiency >= 99%\n",
+    "    pt_at_99 = centered_pt[eff>=0.99][0]\n",
+    "    # calculate fraction of events below trigger efficiency below 99%\n",
+    "    total_events_triggered = offline_jets_pt_kept.size\n",
+    "    total_events_for_physics = offline_jets_pt_kept[offline_jets_pt_kept>=pt_at_99].size\n",
+    "    wasted_frac = (total_events_triggered-total_events_for_physics)/total_events_triggered\n",
+    "\n",
+    "    print(f\"\\n--- INFO for trigger: {threshold} GeV threshold, {sigma} GeV sigma ---\")\n",
+    "    print(\"%40s %i GeV \"%(\"99%% trigger efficiency @ jet pT = \",pt_at_99))\n",
+    "    print(\"%40s %i\" %(\"Number of triggered events = \",total_events_triggered))\n",
+    "    print(\"%40s %i\"%(\"Number of events for analysis = \", total_events_for_physics))\n",
+    "    print(\"%40s %.2f\"%(\"fraction of wasted events = \",wasted_frac))\n",
+    "    print(\"%40s %.1f Hz\"%(\"total rate = \",400*total_events_triggered/total_events)) # arbitrary scaling to get reasonable rate"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8SPC8LUpCplP",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "8SPC8LUpCplP",
-    "outputId": "f2c8bd14-1cf2-4b3e-e331-bf79a0756f75"
-   },
-   "outputs": [],
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2cb6546d",
+   "metadata": {},
    "source": [
-    "## Measuring jet trigger performance\n",
+    "### Challenge: Calo versus particle flow jets\n",
     "\n",
-    "pt_at_99 = centered_pt[eff>=0.99][0]\n",
-    "total_events_triggered = offline_jets_pt_kept.size\n",
-    "total_events_for_physics = offline_jets_pt_kept[offline_jets_pt_kept>=pt_at_99].size\n",
-    "wasted_frac = (total_events_triggered-total_events_for_physics)/total_events_triggered\n",
+    "For the LHC Run 3, the upgraded ATLAS trigger can now reconstruct both calorimeter-based jets and particle flow jets. While calorimeter-based jets are reconstructed from calorimeter topoclusters only, particle flow jets are reconstructed from particle flow objects where calorimeter deposits are linked with tracks to reconstruct a objects with improved momentum measurements and reduced pile-up effects.\n",
     "\n",
-    "print(\"99%% trigger efficiency @ jet pT = %i GeV \"%(pt_at_99))\n",
-    "print(\"Number of triggered events = \", total_events_triggered)\n",
-    "print(\"Number of events for analysis = \", total_events_for_physics)\n",
-    "print(\"fraction of wasted events = %.2f\"%(wasted_frac))"
+    "Due to their superior precision, particle flow jets are what are reconstructed offline for physics analyses. However, they are expensive objects to reconstruct: Tracking is highly CPU intensive!\n",
+    "\n",
+    "For this reason, we cannot afford to reconstruct particle flow jets at the same rate as calo-based jets. On the other hand, the momentum resolution for online particle flow jets is better which means \"sharper\" trigger turn-ons.\n",
+    "\n",
+    "Challenge: Given the following momenta resolutions with respect to offline for online calorimeter jets and online particle flow jets as well as their respective trigger rate constraints, how much higher do you need to adjust the trigger threshold for a pflow jet trigger to be able to afford it? Does it ultimately increase or decrease the physics acceptance for analyses?\n",
+    "\n",
+    "<img align=\"right\" src=\"https://scx1.b-cdn.net/csz/news/800a/2020/1-newprecision.jpg\" width=\"400\" />\n",
+    "\n",
+    "\n",
+    "\n",
+    "| type | sigma | max rate|\n",
+    "-------|-------|---------|\n",
+    "| calo jet | 20 | 55 Hz |\n",
+    "| pflow jet | 5 | 40 Hz | \n",
+    "\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "43779a38",
+   "id": "312e7471",
    "metadata": {},
    "source": [
     "# Exercise: Measuring the performance of a single lepton trigger \n",
@@ -413,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f796c028",
+   "id": "639fe9bf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41389de9",
+   "id": "8510a877",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,11 +485,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23589408",
+   "id": "1db4d070",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "# Loop through all events: Distinguish between \n",
     "# leading electrons from electron triggered events (trigE == True) \n",
     "# and leading electrons in all events.\n",
@@ -516,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcee80bc",
+   "id": "7154faa1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b012e62",
+   "id": "2d3e0e46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,9 +558,8 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "320b7f76",
+   "id": "38abc912",
    "metadata": {
     "id": "FXvtELp2QfmZ"
    },
@@ -579,14 +573,6 @@
     " \n",
     " **Question**: How does this curve look different to the jet trigger turn-ons? Why is it different?\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0ca4c488",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This session consists of two exercises:

(1) Analysing jet trigger turn-on performance with generated pT spectra. This includes a calo vs pflow jet trigger tuning challenge.
(2) Plotting the trigger efficiencies for a single electron trigger in ATLAS MC open data and discussing why it looks different to a jet trigger turn-on.